### PR TITLE
Add support for 2013 extension of Irish PPS Numbers

### DIFF
--- a/stdnum/ie/vat.py
+++ b/stdnum/ie/vat.py
@@ -22,8 +22,10 @@
 The Irish VAT number consists of 8 digits. The last digit is a check
 letter, the second digit may be a number, a letter, "+" or "*".
 
->>> validate('IE 6433435F')
+>>> validate('IE 6433435F') # pre-2013 format
 '6433435F'
+>>> validate('IE 6433435OA') # 2013 format
+'6433435OA'
 >>> validate('6433435E')  # incorrect check digit
 Traceback (most recent call last):
     ...
@@ -53,9 +55,14 @@ def calc_check_digit(number):
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     alphabet = 'WABCDEFGHIJKLMNOPQRSTUV'
-    number = (7 - len(number)) * '0' + number
-    return alphabet[sum((8 - i) * int(n) for i, n in enumerate(number)) % 23]
-
+    number = number.zfill(7)
+    if len(number) < 8 or number[7] in ' W':
+        # for pre-2013 compatibility, W or space are not significant
+        extra_number = 0
+    else:
+        extra_number = 9 * (ord(number[7]) - 64)
+    return alphabet[(sum((8 - i) * int(n) for i, n in enumerate(number[:7])) +
+        + extra_number) % 23]
 
 def validate(number):
     """Checks to see if the number provided is a valid VAT number. This checks
@@ -63,19 +70,19 @@ def validate(number):
     number = compact(number)
     if not number[:1].isdigit() or not number[2:7].isdigit():
         raise InvalidFormat()
-    if len(number) != 8:
+    if len(number) not in (8, 9):
         raise InvalidLength()
     if number[:7].isdigit():
         # new system
-        if number[-1] != calc_check_digit(number[:-1]):
+        if number[7] != calc_check_digit(number[:7] + number[8:]):
             raise InvalidChecksum()
     elif number[1] in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+*':
         # old system
-        if number[-1] != calc_check_digit(number[2:-1] + number[0]):
+        if number[7] != calc_check_digit(number[2:7] + number[0]):
             raise InvalidChecksum()
     else:
         raise InvalidFormat()
-    return number
+    return compact(number)
 
 
 def is_valid(number):

--- a/tests/test_eu_vat.doctest
+++ b/tests/test_eu_vat.doctest
@@ -387,6 +387,8 @@ These have been found online and should all be valid numbers.
 ... IE6599001W
 ... IE8D79739I
 ... IE9Y71814N
+... IE6433435OA
+... IE6433435IH
 ...
 ... IT - 01404480202
 ... IT 0 0 6 1 8 2 8 0 4 9 9


### PR DESCRIPTION
Support the new extra letter at the end of PPS numbers (weight=9), while maintaining compatibility with the old format.
Add a few test PPS numbers, keep `ie` coverage at 100%.

References:
- https://www.welfare.ie/en/Pages/PPSN.aspx
- http://www.citizensinformation.ie/en/social_welfare/irish_social_welfare_system/personal_public_service_number.html
