### PR TITLE
Add support for Norwegian organization and VAT numbers

### DIFF
--- a/docs/stdnum.no.mva
+++ b/docs/stdnum.no.mva
@@ -1,0 +1,5 @@
+stdnum.no.mva
+=============
+
+.. automodule:: stdnum.no.mva
+   :members:

--- a/docs/stdnum.no.orgnr
+++ b/docs/stdnum.no.orgnr
@@ -1,0 +1,5 @@
+stdnum.no.orgnr
+===============
+
+.. automodule:: stdnum.no.orgnr
+   :members:

--- a/stdnum/__init__.py
+++ b/stdnum/__init__.py
@@ -82,6 +82,8 @@ Currently this package supports the following formats:
 * nl.btw: BTW-nummer (Omzetbelastingnummer, the Dutch VAT number)
 * nl.onderwijsnummer: Onderwijsnummer (Dutch student school number)
 * nl.postcode: Postcode (Dutch postal code)
+* no.mva: MVA (Merverdiavgift, Norwegian VAT number)
+* no.orgnr: Orgnr (Organisasjonsnummer, Norwegian organization number)
 * pl.nip: NIP (Numer Identyfikacji Podatkowej, Polish VAT number)
 * pt.nif: NIF (Número de identificação fiscal, Portuguese VAT number)
 * ro.cf: CF (Cod de înregistrare în scopuri de TVA, Romanian VAT number)

--- a/stdnum/no/__init__.py
+++ b/stdnum/no/__init__.py
@@ -1,0 +1,24 @@
+# __init__.py - collection of Norwegian numbers
+# coding: utf-8
+#
+# Copyright (C) 2012 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Collection of Norwegian numbers."""
+
+# provide vat as an alias
+from stdnum.no import mva as vat

--- a/stdnum/no/mva.py
+++ b/stdnum/no/mva.py
@@ -18,15 +18,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-"""MVA nummmer (Merverdiavgift, Norwegian VAT number).
+"""MVA nummer (Merverdiavgift, Norwegian VAT number).
 
 The VAT number is standard Norwegian organization number
 (organisasjonsnummer) with 'MVA' as suffix. The number is
 9-digit code where the last digit is a weighted MOD11 checksum.
 
->>> validate('995525828 MVA')
-'995525828 MVA'
->>> validate('995525829 MVA')  # invalid check digit
+>>> validate('NO 995 525 828 MVA')
+'995525828'
+>>> validate('NO 995 525 829 MVA')  # invalid check digit
 Traceback (most recent call last):
     ...
 InvalidChecksum: ...
@@ -45,6 +45,8 @@ def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
+    if number.startswith('NO'):
+        number = number[2:]
     if number.endswith('MVA'):
         number = number[:-3]
     return number

--- a/stdnum/no/mva.py
+++ b/stdnum/no/mva.py
@@ -1,0 +1,57 @@
+# mva.py - functions for handling Norwegian VAT numbers
+# coding: utf-8
+#
+# Copyright (C) 2012, 2013 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""MVA nummmer (Merverdiavgift, Norwegian VAT number).
+
+The VAT number is standard Norwegian organization number
+(organisasjonsnummer) with 'MVA' as suffix. The number is
+9-digit code where the last digit is a weighted MOD11 checksum.
+
+>>> validate('995525828 MVA')
+'995525828 MVA'
+>>> validate('995525829 MVA')  # invalid check digit
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+"""
+
+from stdnum.no import orgnr
+from stdnum.exceptions import *
+from stdnum.util import clean
+
+# use the same checksum functions as orgnr
+checksum = orgnr.checksum
+is_valid = orgnr.is_valid
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    number = clean(number, ' ').upper().strip()
+    if number.endswith('MVA'):
+        number = number[:-3]
+    return number
+
+
+def validate(number):
+    """Checks to see if the number provided is a valid organization
+    number. This checks the length, formatting and check digit."""
+    number = compact(number)
+    return orgnr.validate(number)

--- a/stdnum/no/mva.py
+++ b/stdnum/no/mva.py
@@ -47,8 +47,6 @@ def compact(number):
     number = clean(number, ' ').upper().strip()
     if number.startswith('NO'):
         number = number[2:]
-    if number.endswith('MVA'):
-        number = number[:-3]
     return number
 
 
@@ -56,4 +54,7 @@ def validate(number):
     """Checks to see if the number provided is a valid organization
     number. This checks the length, formatting and check digit."""
     number = compact(number)
-    return orgnr.validate(number)
+    if not number.endswith('MVA'):
+        raise InvalidFormat()
+    orgnr.validate(number[:-3])
+    return number

--- a/stdnum/no/orgnr.py
+++ b/stdnum/no/orgnr.py
@@ -1,0 +1,70 @@
+# orgnr.py - functions for handling Norwegian organization numbers
+# coding: utf-8
+#
+# Copyright (C) 2012, 2013 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Orgnr (Organisasjonsnummer, Norwegian organization number).
+
+The number is 9-digit code where the last digit is a weighted MOD11
+checksum.
+
+>>> validate('995525828')
+'995525828'
+>>> validate('995525829')  # invalid check digit
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+"""
+
+from stdnum.exceptions import *
+from stdnum.util import clean
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    number = clean(number, ' ').upper().strip()
+    return number
+
+
+def checksum(number):
+    """Calculate the checksum."""
+    weights = (3, 2, 7, 6, 5, 4, 3, 2)
+    return 11 - sum(weights[i] * int(n) for i, n in enumerate(number)) % 11
+
+
+def validate(number):
+    """Checks to see if the number provided is a valid organization
+    number. This checks the length, formatting and check digit."""
+    number = compact(number)
+    if not number.isdigit():
+        raise InvalidFormat()
+    if len(number) != 9:
+        raise InvalidLength()
+    if checksum(number[:8]) != int(number[8]):
+        raise InvalidChecksum()
+    return number
+
+
+def is_valid(number):
+    """Checks to see if the number provided is a valid organization
+    number. This checks the length, formatting and check digit."""
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False


### PR DESCRIPTION
Adds support for Norwegian organisation numbers (orgnr) and VAT numbers (MVA).

Canonical reference (in Norwegian): http://www.brreg.no/samordning/organisasjonsnummer.html