### PR TITLE
ISO6346 - Bug fix for the case when the checksum is 10

### DIFF
--- a/stdnum/iso6346.py
+++ b/stdnum/iso6346.py
@@ -69,7 +69,7 @@ def validate(number):
         raise InvalidLength()
     if not _iso6346_re.match(number):
         raise InvalidFormat()
-    if calc_check_digit(number[:-1]) != number[-1]:
+    if calc_check_digit(number[:-1])[-1:] != number[-1]:
         raise InvalidChecksum()
     return number
 

--- a/tests/test_iso6346.doctest
+++ b/tests/test_iso6346.doctest
@@ -39,6 +39,8 @@ True
 'TCNU7200794'
 >>> iso6346.validate('tolu4734787')
 'TOLU4734787'
+>>> iso6346.validate('GYOU4047990')
+'GYOU4047990'
 
 
 Test with invalid numbers:


### PR DESCRIPTION
When the container code checksum is 10, the function compares it with the last digit of the container code (that, in this case, would be 0).

A simple fix, we just need to compare the last digit in every case.

The fix contains a test that exposes the bug.