### PR TITLE
add a SIRET module

### DIFF
--- a/README
+++ b/README
@@ -51,6 +51,7 @@ Currently this package supports the following formats:
  * HETU (Henkilötunnus, Finnish personal identity code)
  * Y-tunnus (Finnish business identifier)
  * SIREN (a French company identification number)
+ * SIRET (a French company's establishment identification number)
  * n° TVA (taxe sur la valeur ajoutée, French VAT number)
  * SEDOL number (Stock Exchange Daily Official List number)
  * VAT (United Kingdom (and Isle of Man) VAT registration number)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'python-stdnum'
-copyright = u'2013, Arthur de Jong'
+copyright = u'2013, Arthur de Jong. 2016, Yoann Aubineau'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,6 +127,7 @@ Available formats
    fi.hetu
    fi.ytunnus
    fr.siren
+   fr.siret
    fr.tva
    gb.sedol
    gb.vat

--- a/stdnum/__init__.py
+++ b/stdnum/__init__.py
@@ -67,6 +67,7 @@ Currently this package supports the following formats:
 * fi.hetu: HETU (Henkilötunnus, Finnish personal identity code)
 * fi.ytunnus: Y-tunnus (Finnish business identifier)
 * fr.siren: SIREN (a French company identification number)
+* fr.siret: SIRET (a French company's establishment identification number)
 * fr.tva: n° TVA (taxe sur la valeur ajoutée, French VAT number)
 * gb.sedol: SEDOL number (Stock Exchange Daily Official List number)
 * gb.vat: VAT (United Kingdom (and Isle of Man) VAT registration number)

--- a/stdnum/fr/siret.py
+++ b/stdnum/fr/siret.py
@@ -1,0 +1,101 @@
+# siret.py - functions for handling French SIREN numbers
+# coding: utf-8
+#
+# Copyright (C) 2012, 2013 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""SIRET (a French company's establishment identification number).
+
+The SIRET (Système d'Identification du Répertoire des ETablissements)
+is a 14 digit number used to identify French companies' establishments
+and facilities. The Luhn checksum is used to validate the numbers.
+
+>>> compact('732 829 320 00074')
+'73282932000074'
+>>> validate('73282932000074')
+'73282932000074'
+>>> validate('73282932000079')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> to_siren('732 829 320 00074')
+'732 829 320'
+>>> to_siren('73282932000074')
+'732829320'
+>>> to_tva('732 829 320 00074')
+'44 732 829 320'
+>>> to_tva('73282932000074')
+'44732829320'
+"""
+
+from stdnum import luhn
+from stdnum.exceptions import *
+from stdnum.fr import siren
+from stdnum.util import clean
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    return clean(number, ' ').strip()
+
+
+def validate(number):
+    """Checks to see if the number provided is a valid number. This checks
+    the length, formatting and check digit."""
+    number = compact(number)
+    if not number.isdigit():
+        raise InvalidFormat()
+    if len(number) != 14:
+        raise InvalidLength()
+    luhn.validate(number)
+    siren.validate(number[:9])
+    return number
+
+
+def is_valid(number):
+    """Checks to see if the number provided is a valid number. This checks
+    the length, formatting and check digit."""
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False
+
+
+def to_siren(number):
+    """Return SIREN number from given SIRET number.
+
+    The SIREN number is the 9 first digits of the SIRET number.
+    """
+    _siren = []
+    digit_count = 0
+    for char in number:
+        if digit_count < 9:
+            _siren.append(char)
+            if char.isdigit():
+                digit_count += 1
+    return ''.join(_siren)
+
+
+def to_tva(number):
+    """Return TVA number from given SIRET number.
+
+    The TVA number is built from the SIREN number, prepended by two extra error
+    checking digits.
+    """
+    return siren.to_tva(to_siren(number))
+


### PR DESCRIPTION
SIRET stands for "Système d’identification du répertoire des établissements". It's a French company's establishment identification number that appends a 4-digit number to the company's SIREN, plus a single digit for error detection using the Luhn algorithm.