### PR TITLE
Add tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = {py26,py27,py34,py35,pypy}
+
+[testenv]
+deps = nose
+commands = nosetests


### PR DESCRIPTION
[Tox](https://tox.readthedocs.io/en/latest/) is a python library for running test in diferent environments, so its usefull to automate the testing on the supported versions. The added file uses [nosetests](http://nose.readthedocs.io/en/latest/man.html) to discover all the test docstrings and runs them for each python version. 

For testing you just have to type the following commands. 

> pip install tox
> tox 

Note that if your local machine does not have all the supported python interpreters it will fail. You can fix it with the --skip-missing-interpreters flag on the tox command. 