### PR TITLE
Please don't rely on stable set ordering.

### DIFF
--- a/stdnum/eu/vat.py
+++ b/stdnum/eu/vat.py
@@ -43,7 +43,7 @@ from stdnum.exceptions import *
 from stdnum.util import clean, get_cc_module, get_soap_client
 
 
-country_codes = set([
+_country_codes = set([
     'at', 'be', 'bg', 'cy', 'cz', 'de', 'dk', 'ee', 'es', 'fi', 'fr', 'gb',
     'gr', 'hr', 'hu', 'ie', 'it', 'lt', 'lu', 'lv', 'mt', 'nl', 'pl', 'pt',
     'ro', 'se', 'si', 'sk',
@@ -63,7 +63,7 @@ def _get_cc_module(cc):
     cc = cc.lower()
     if cc == 'el':
         cc = 'gr'
-    if cc not in country_codes:
+    if cc not in _country_codes:
         return
     if cc not in _country_modules:
         _country_modules[cc] = get_cc_module(cc, 'vat')
@@ -105,7 +105,7 @@ def guess_country(number):
     for which it is valid. This returns lower case codes and returns gr (not
     el) for Greece."""
     return [cc
-            for cc in country_codes
+            for cc in _country_codes
             if _get_cc_module(cc).is_valid(number)]
 
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that python-stdnum could not be built reproducibly as it relies
on a stable set ordering when generating the documentation.

This has been filed in Debian as #88652

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/886522

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>