### PR TITLE
Improve ES VAT/NIF validation for NIF starting with K, L or M

### DIFF
--- a/stdnum/es/cif.py
+++ b/stdnum/es/cif.py
@@ -34,8 +34,10 @@ InvalidChecksum: ...
 Traceback (most recent call last):
     ...
 InvalidLength: ...
->>> validate('M-1234567-L')
-'M1234567L'
+>>> validate('M-1234567-L')  # valid NIF but not valid CIF
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
 >>> validate('O-1234567-L')  # invalid first character
 Traceback (most recent call last):
     ...
@@ -72,14 +74,7 @@ def validate(number):
         raise InvalidFormat()
     if len(number) != 9:
         raise InvalidLength()
-    if number[0] in 'KLM':
-        # K: Spanish younger than 14 year old
-        # L: Spanish living outside Spain without DNI
-        # M: granted the tax to foreigners who have no NIE
-        # these use the old checkdigit algorithm (the DNI one)
-        if number[-1] != dni.calc_check_digit(number[1:-1]):
-            raise InvalidChecksum()
-    elif number[0] in 'ABCDEFGHJNPQRSUVW':
+    if number[0] in 'ABCDEFGHJNPQRSUVW':
         # there seems to be conflicting information on which organisation types
         # should have which type of check digit (alphabetic or numeric) so
         # we support either here

--- a/stdnum/es/nif.py
+++ b/stdnum/es/nif.py
@@ -64,7 +64,14 @@ def validate(number):
         raise InvalidFormat()
     if len(number) != 9:
         raise InvalidLength()
-    if number[0].isdigit():
+    if number[0] in 'KLM':
+        # K: Spanish younger than 14 year old
+        # L: Spanish living outside Spain without DNI
+        # M: granted the tax to foreigners who have no NIE
+        # these use the old checkdigit algorithm (the DNI one)
+        if number[-1] != dni.calc_check_digit(number[1:-1]):
+            raise InvalidChecksum()
+    elif number[0].isdigit():
         # natural resident
         dni.validate(number)
     elif number[0] in 'XYZ':

--- a/tests/test_es_cif.doctest
+++ b/tests/test_es_cif.doctest
@@ -1,0 +1,74 @@
+test_es_cif.doctest - more detailed doctests for stdnum.es.cif module
+
+Copyright (C) 2018 Gerard Dalmau
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.es.cif. It
+tries to cover more corner cases and detailed functionality that is not
+really useful as module documentation.
+
+>>> from stdnum.es import cif
+>>> from stdnum.exceptions import *
+
+
+Valid DNI
+
+>>> cif.is_valid('11111111H')
+False
+
+
+Invalid DNI
+
+>>> cif.is_valid('11111111T')
+False
+
+
+Valid CIF
+
+>>> cif.is_valid('A11111119')
+True
+
+
+Invalid CIF
+
+>>> cif.is_valid('A11111118')
+False
+
+
+Valid NIE
+
+>>> cif.is_valid('X1111111G')
+False
+
+
+Invalid NIE
+
+>>> cif.is_valid('X1111111A')
+False
+
+
+Valid NIF - Not classified as DNI, CIF or NIE
+
+>>> cif.is_valid('L1111111G')
+False
+
+
+Invalid NIF
+
+>>> cif.is_valid('L1111111C')
+False

--- a/tests/test_es_cups.doctest
+++ b/tests/test_es_cups.doctest
@@ -1,4 +1,4 @@
-test_my_nric.doctest - more detailed doctests for stdnum.es.cups module
+test_es_cups.doctest - more detailed doctests for stdnum.es.cups module
 
 Copyright (C) 2016 David García Garzón
 Copyright (C) 2016 Arthur de Jong

--- a/tests/test_es_dni.doctest
+++ b/tests/test_es_dni.doctest
@@ -1,0 +1,74 @@
+test_es_dni.doctest - more detailed doctests for stdnum.es.dni module
+
+Copyright (C) 2018 Gerard Dalmau
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.es.dni. It
+tries to cover more corner cases and detailed functionality that is not
+really useful as module documentation.
+
+>>> from stdnum.es import dni
+>>> from stdnum.exceptions import *
+
+
+Valid DNI
+
+>>> dni.is_valid('11111111H')
+True
+
+
+Invalid DNI
+
+>>> dni.is_valid('11111111T')
+False
+
+
+Valid CIF
+
+>>> dni.is_valid('A11111119')
+False
+
+
+Invalid CIF
+
+>>> dni.is_valid('A11111118')
+False
+
+
+Valid NIE
+
+>>> dni.is_valid('X1111111G')
+False
+
+
+Invalid NIE
+
+>>> dni.is_valid('X1111111A')
+False
+
+
+Valid NIF - Not classified as DNI, CIF or NIE
+
+>>> dni.is_valid('L1111111G')
+False
+
+
+Invalid NIF
+
+>>> dni.is_valid('L1111111C')
+False

--- a/tests/test_es_nie.doctest
+++ b/tests/test_es_nie.doctest
@@ -1,0 +1,74 @@
+test_es_nie.doctest - more detailed doctests for stdnum.es.nie module
+
+Copyright (C) 2018 Gerard Dalmau
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.es.nie. It
+tries to cover more corner cases and detailed functionality that is not
+really useful as module documentation.
+
+>>> from stdnum.es import nie
+>>> from stdnum.exceptions import *
+
+
+Valid DNI
+
+>>> nie.is_valid('11111111H')
+False
+
+
+Invalid DNI
+
+>>> nie.is_valid('11111111T')
+False
+
+
+Valid CIF
+
+>>> nie.is_valid('A11111119')
+False
+
+
+Invalid CIF
+
+>>> nie.is_valid('A11111118')
+False
+
+
+Valid NIE
+
+>>> nie.is_valid('X1111111G')
+True
+
+
+Invalid NIE
+
+>>> nie.is_valid('X1111111A')
+False
+
+
+Valid NIF - Not classified as DNI, CIF or NIE
+
+>>> nie.is_valid('L1111111G')
+False
+
+
+Invalid NIF
+
+>>> nie.is_valid('L1111111C')
+False

--- a/tests/test_es_referenciacatastral.doctest
+++ b/tests/test_es_referenciacatastral.doctest
@@ -1,4 +1,5 @@
-test_es_referenciacatastral.doctest - more detailed doctests
+test_es_referenciacatastral.doctest - more detailed doctests for
+stdnum.es.referenciacatastral module
 
 Copyright (C) 2016 David García Garzón
 Copyright (C) 2015-2017 Arthur de Jong

--- a/tests/test_es_vat.doctest
+++ b/tests/test_es_vat.doctest
@@ -1,0 +1,74 @@
+test_es_vat.doctest - more detailed doctests for stdnum.es.vat module
+
+Copyright (C) 2018 Gerard Dalmau
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.es.vat. It
+tries to cover more corner cases and detailed functionality that is not
+really useful as module documentation.
+
+>>> from stdnum.es import vat
+>>> from stdnum.exceptions import *
+
+
+Valid DNI
+
+>>> vat.is_valid('11111111H')
+True
+
+
+Invalid DNI
+
+>>> vat.is_valid('11111111T')
+False
+
+
+Valid CIF
+
+>>> vat.is_valid('A11111119')
+True
+
+
+Invalid CIF
+
+>>> vat.is_valid('A11111118')
+False
+
+
+Valid NIE
+
+>>> vat.is_valid('X1111111G')
+True
+
+
+Invalid NIE
+
+>>> vat.is_valid('X1111111A')
+False
+
+
+Valid NIF - Not classified as DNI, CIF or NIE
+
+>>> vat.is_valid('L1111111G')
+True
+
+
+Invalid NIF
+
+>>> vat.is_valid('L1111111C')
+False


### PR DESCRIPTION
#### Dictionary

Little introduction explaining identification numbers in Spain:

- NIF (Número de Identificación Fiscal) → Spanish VAT
- CIF (Código de Identificación Fiscal) → Spanish juridical person identification number
- DNI (Documento Nacional de Identidad) → Spanish natural person identification card that contains NIF
- NIE (Número de Identidad de Extranjero) →  Spanish natural person identification number for foreigners

## Issue

Old NIF starting with K, L or M are validated as CIF. Nowadays identification numbers starting with these letters are identified as NIF and not CIF. It cannot be identified as a DNI or NIE because of the following:

- It is assigned to a natural person so it cannot be a juridical identification number (CIF)
- The natural person doesn't have a national card (DNI)
- The natural person doesn't have a foreigner identification number (NIE)

## Development

- [x] Added tests checking valid and invalid DNIs, CIFs and NIEs for the following:
    - DNI
    - CIF
    - NIE
    - VAT/NIF
- [x] Moved the code of CIF validation for numbers starting with K, L or M code to NIF validation

## Documentation checked
- [Código de identificación fiscal (CIF) - Wikipedia](https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal): The first letter for CIF numbers can only be one of the following: ABCDEFGHJNPQRSUVW
- [Número de identificación fiscal (NIF) - Wikipedia](https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal)
- [Real Decreto 1065/2007](https://www.boe.es/buscar/act.php?id=BOE-A-2007-15984): It states that natural persons can get a NIF but not a DNI so it is not classified as DNI.
> Artículo 19. El número de identificación fiscal de las personas físicas de nacionalidad española.

> 2. Los españoles que realicen o participen en operaciones de naturaleza o con trascendencia tributaria y no estén obligados a obtener el documento nacional de identidad por residir en el extranjero o por ser menores de 14 años, deberán obtener un número de identificación fiscal propio. Para ello, podrán solicitar el documento nacional de identidad con carácter voluntario **o solicitar de la Administración tributaria la asignación de un número de identificación fiscal**. Este último estará integrado por nueve caracteres con la siguiente composición: una letra inicial destinada a indicar la naturaleza de este número, que será la L para los españoles residentes en el extranjero y la K para los españoles que, residiendo en España, sean menores de 14 años; siete caracteres alfanuméricos y un carácter de verificación alfabético.

## Additional documentation
- [NIF, DNI, CIF, NIE validator](https://comunidadhorizontal.com/utiles/validar-cif-nif-nie/)
- [Orden EHA/451/2008](http://www.boe.es/diario_boe/txt.php?id=BOE-A-2008-3580) , de 20 de febrero, por la que se regula la composición del número de identificación fiscal de las personas jurídicas y entidades sin personalidad jurídica, principalmente: it regulates fiscal identification numbers from juridic persons
- http://www.juntadeandalucia.es/servicios/madeja/contenido/recurso/677
- https://www.abanlex.com/2014/12/el-cif-paso-a-denominarse-nif-siempre-tambien-para-las-sociedades-mas-info/
