### PR TITLE
[FIX] do: Use HTTPS for WSDL as HTTP was deprecated

### DIFF
--- a/stdnum/do/rnc.py
+++ b/stdnum/do/rnc.py
@@ -54,7 +54,7 @@ whitelist = set('''
 '''.split())
 
 
-dgii_wsdl = 'http://www.dgii.gov.do/wsMovilDGII/WSMovilDGII.asmx?WSDL'
+dgii_wsdl = 'https://www.dgii.gov.do/wsMovilDGII/WSMovilDGII.asmx?WSDL'
 """The WSDL URL of DGII validation service."""
 
 


### PR DESCRIPTION
The regulator changed their site to use HTTPS by default; making this resource unavailable through HTTP.