### PR TITLE
This PR fix issue when response comes with 2 records instead of one for same RNC

### DIFF
--- a/stdnum/do/rnc.py
+++ b/stdnum/do/rnc.py
@@ -148,7 +148,8 @@ def check_dgii(number, timeout=30):  # pragma: no cover
         result = result['GetContribuyentesResult']  # PySimpleSOAP only
     if result == '0':
         return
-    return _convert_result(result)
+    result = [x for x in result.split('@@@')]
+    return _convert_result(result[0])
 
 
 def search_dgii(keyword, end_at=10, start_at=1, timeout=30):  # pragma: no cover


### PR DESCRIPTION
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 651, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/odoo/odoo-server/src/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 693, in dispatch
    result = self._call_function(**self.params)
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 342, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/odoo-server/src/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 335, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 937, in __call__
    return self.method(*args, **kw)
  File "/odoo/odoo-server/src/odoo/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/odoo/odoo-server/src/odoo/addons/web/controllers/main.py", line 938, in call_button
    action = self._call_kw(model, method, args, {})
  File "/odoo/odoo-server/src/odoo/addons/web/controllers/main.py", line 926, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/odoo-server/src/odoo/odoo/api.py", line 689, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/odoo/odoo-server/src/odoo/odoo/api.py", line 680, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/odoo-server/src/custom/iterativo/dominican_addons/ncf_pos/models/pos_order.py", line 225, in action_pos_order_invoice
    res = super(PosOrder, self).action_pos_order_invoice()
  File "/odoo/odoo-server/src/odoo/addons/point_of_sale/models/pos_order.py", line 655, in action_pos_order_invoice
    new_invoice = Invoice.with_context(local_context).sudo().create(inv)
  File "/odoo/odoo-server/src/custom/iterativo/dominican_addons/ncf_manager/models/account_invoice.py", line 329, in create
    if len(partner_id.vat) not in [9, 11] or not rnc.check_dgii(str(partner_id.vat)):
  File "/odoo/venv/lib/python3.7/site-packages/stdnum/do/rnc.py", line 151, in check_dgii
    return _convert_result(result)
  File "/odoo/venv/lib/python3.7/site-packages/stdnum/do/rnc.py", line 115, in _convert_result
    for key, value in json.loads(result.replace('\t', '\\t')).items())
  File "/usr/src/Python-3.7.0/Lib/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/src/Python-3.7.0/Lib/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 142 (char 141)