### PR TITLE
Add string length constrain for iso6346 calc_check_digit function

### DIFF
--- a/stdnum/iso6346.py
+++ b/stdnum/iso6346.py
@@ -61,6 +61,8 @@ def calc_check_digit(number):
     """Calculate check digit and return it for the 10 digit owner code and
     serial number."""
     number = compact(number)
+    if len(number) != 10:
+        raise InvalidLength()    
     alphabet = '0123456789A BCDEFGHIJK LMNOPQRSTU VWXYZ'
     return str(sum(
         alphabet.index(n) * pow(2, i)


### PR DESCRIPTION
I am very excited to make my first GitHub contribution, please be lenient if I have made something wrong in the process.
As a person active in the container leasing business, I was happy to see your package. It is very good and I am using it not only for iso6346 numbers verification but also for Polish VAT No verification (NIP number).
My fix puts constrain on length of the calc_check_digit being checked.
Without it, there is a risk for hidden errors to occur in the calculation.
I have used the same syntax as found in the 'validate' function.