### PR TITLE
Swiss ESR verification

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-11-02  Kurt Keller <Kurt@pinboard.jp>
+
+	* stdnum/ch/esr.py,
+	  tests/test_ch_esr.doctest, docs/stdnum.ch.esr.rst: Add Swiss
+	  ESR numbers
+
+	  The Swiss ESR/ISR/QR-reference is a reference number used on
+	  payment slips.
+
 2019-10-27  Arthur de Jong <arthur@arthurdejong.org>
 
 	* [6ca5b53] stdnum/at/postleitzahl.dat, stdnum/be/banks.dat,

--- a/README
+++ b/README
@@ -43,6 +43,7 @@ Currently this package supports the following formats:
  * Swiss social security number ("Sozialversicherungsnummer")
  * UID (Unternehmens-Identifikationsnummer, Swiss business identifier)
  * VAT, MWST, TVA, IVA, TPV (Mehrwertsteuernummer, the Swiss VAT number)
+ * ESR, ISR, QR-reference (reference number on Swiss payment slips)
  * RUT (Rol Único Tributario, Chilean national tax number)
  * RIC No. (Chinese Resident Identity Card Number)
  * NIT (Número De Identificación Tributaria, Colombian identity code)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,6 +128,7 @@ Available formats
    ch.ssn
    ch.uid
    ch.vat
+   ch.esr
    cl.rut
    cn.ric
    co.nit

--- a/docs/stdnum.ch.esr.rst
+++ b/docs/stdnum.ch.esr.rst
@@ -1,0 +1,5 @@
+stdnum.ch.esr
+=============
+
+.. automodule:: stdnum.ch.esr
+   :members:

--- a/stdnum/ch/esr.py
+++ b/stdnum/ch/esr.py
@@ -1,0 +1,105 @@
+# esr.py - functions for handling Swiss EinzahlungsSchein mit Referenznummer
+# coding: utf-8
+#
+# Copyright (C) 2019 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""ESR, ISR, QR-reference (Eizahlungsschein mit Referenznummer,
+                           pay-in slip with reference number)
+
+The Swiss ESR/ISR/QR-reference is a reference number used on payment slips. 
+
+An ISR (inpayment slip with reference number) refers to the orange payment
+slip in Switzerland with which money can be transferred to an account. It
+contains a machine-readable encoding line that contains a participant number
+and reference number. The participant number ensures the crediting to the
+corresponding Post account. The reference number enables the creditor to
+identify the invoice recipient. In this way, the payment process can be
+handled entirely electronically, from the invoicing date to the booking of
+the amount at the creditor.
+
+It consists of 26 numerical characters followed by a Modulo 10 recursive check
+digit. It is printed in blocks of 5 characters (beginning with 2 characters,
+then 5x5-character groups). Leading zeros digits can be omitted.
+
+This module always prints all digits, including optional leading zeros, so
+it is compatible with the newer QR-reference.
+
+More information:
+
+* https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf
+
+>>> validate('21 00000 00003 13947 14300 09017')
+'210000000003139471430009017'
+>>> validate('210000000003139471430009017')
+'210000000003139471430009017'
+>>> validate('210000000003139471430009016')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> format('210000000003139471430009017')
+'21 00000 00003 13947 14300 09017'
+"""
+
+from stdnum.exceptions import *
+from stdnum.util import clean, isdigits
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips
+    surrounding whitespace and separators."""
+    return clean(number, ' ').strip()
+
+
+def calc_check_digit(number, carry_over='0', alphabet='0946827135'):
+    """Calculate the check digit for number. The number passed should
+    not have the check digit included."""
+    number = compact(number)
+    if len(number) == 0:
+        return (str((10-int(carry_over))%10))
+    new_alphabet = alphabet[int(carry_over):] + alphabet[:int(carry_over)]
+    new_carry_over = new_alphabet[int(number[0])]
+    return (calc_check_digit(number[1:], new_carry_over))
+
+
+def validate(number):
+    """Check if the number is a valid ESR. This checks the length, formatting
+    and check digit."""
+    number = compact(number)
+    if len(number) > 27:
+        raise InvalidLength()
+    if not isdigits(number):
+        raise InvalidFormat()
+    if number[-1] != calc_check_digit(number[:-1]):
+        raise InvalidChecksum()
+    return number
+
+
+def is_valid(number):
+    """Check if the number is a valid ESR."""
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False
+
+
+def format(number):
+    """Reformat the number to the standard presentation format."""
+    number = 27*"0" + compact(number)
+    number = number[-27:]
+    return number[:2] + ' ' + ' '.join(
+        number[i:i + 5] for i in range(2, len(number), 5))

--- a/tests/test_ch_esr.doctest
+++ b/tests/test_ch_esr.doctest
@@ -1,0 +1,91 @@
+test_ch_esr.doctest - more detailed doctests for the stdnum.ch.esr module
+
+Copyright (C) 2019 Arthur de Jong
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.ch.esr module.
+
+>>> from stdnum.ch import esr
+>>> from stdnum.exceptions import *
+
+
+Some more detailed tests.
+
+>>> esr.validate('210000000003139471430009016')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> esr.validate('2100000000031394714300090168')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> esr.validate('21000000000313947143000TE45')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+
+
+These have been taken from actual payment slips and should all be valid numbers.
+
+>>> numbers = '''
+...
+... 20 12440 00000 46370 02019 05153
+... 1009 76741 00001 47457 50114
+... 1001007711461312058
+... 361610000000000020190704093
+... 31 23711 80610 58530 00071 92101
+... 18 78583
+... 36 13030 00000 00000 00000 04142
+... 01 73575 51208 21125 03398 69724
+... 2101315000320229184501
+... 90 00170 00000 00214 95962 25686
+... 432130000000000573490016096
+... 201244000000463700201900994
+... 32 29790 00000 19151 00002 79617
+...
+... '''
+>>> [x for x in numbers.splitlines() if x and not esr.is_valid(x)]
+[]
+
+
+All assertions should pass.
+
+>>> numbers = '''
+...
+... 20 12440 00000 46370 02019 05153
+... 1009 76741 00001 47457 50114
+... 1001007711461312058
+... 361610000000000020190704093
+... 31 23711 80610 58530 00071 92101
+... 18 78583
+... 36 13030 00000 00000 00000 04142
+... 01 73575 51208 21125 03398 69724
+... 2101315000320229184501
+... 90 00170 00000 00214 95962 25686
+... 432130000000000573490016096
+... 201244000000463700201900994
+... 32 29790 00000 19151 00002 79617
+...
+... '''
+>>> for number in numbers.splitlines():
+...   if number:
+...     assert esr.is_valid(number)
+...     assert esr.validate(number) == esr.format(number)
+...     assert esr.calc_check_digit(esr.compact(number)[:-1]) == number[-1]
+... 
+>>> 


### PR DESCRIPTION
Added a module for Swiss ESR numbers (reference number on Swiss payment slips).

- With the code in stdnum/ch/esr.py I'm confident. However, I don't know whether another module does compatible verification. I created the verification from scratch using the available online docs from the Swiss payment services provider (SIX) and PostFinance (financial institution).
- With the files docs/stdnum.ch.esr.rst and tests/test_ch_esr.doctest I'm not really sure what they do; I tried to create them by looking at similar files.
- The changes to ChangeLog, README and docs/index.rst are in a separate commit, because I don't know whether you want to do that by yourself to keep things consistent.

I added this module because I started to use qrbill for creating the new standard Swiss payment slips. qrbill uses validators for IBAN validation, but sofar does not do any validation on reference numbers. I intend to change validations over from validators to stdnum, since stdnum has all the required validations, excpet for ESR, which can be added with this pull request.