### PR TITLE
Update isin.py

### DIFF
--- a/stdnum/isin.py
+++ b/stdnum/isin.py
@@ -47,7 +47,7 @@ from stdnum.util import clean
 
 # all valid ISO 3166-1 alpha-2 country codes
 _iso_3116_1_country_codes = [
-    'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR', 'AS', 'AT',
+    'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AN', 'AO', 'AQ', 'AR', 'AS', 'AT',
     'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI',
     'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BV', 'BW', 'BY',
     'BZ', 'CA', 'CC', 'CD', 'CF', 'CG', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN',


### PR DESCRIPTION
added 'AN' to _iso_3116_1_country_codes so that the SCHLUMBERGER NV ISIN 'AN8068571086' is valid.

Fixing issue SCHLUMBERGER NV ISIN 'AN8068571086' invalid #173