### PR TITLE
New BTW identification number (NL)

### DIFF
--- a/stdnum/nl/btw.py
+++ b/stdnum/nl/btw.py
@@ -32,15 +32,31 @@ More information:
 '004495445B01'
 >>> validate('NL4495445B01')
 '004495445B01'
+>>> validate('NL002455799B11')
+'002455799B11'
 >>> validate('123456789B90')
 Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
 
+import re
+import string
+
 from stdnum.exceptions import *
 from stdnum.nl import bsn
 from stdnum.util import clean, isdigits
+
+
+# regular expression for matching number
+_btw_re = re.compile(r'(?:NL)?[0-9A-Z+*]{10}[0-9]{2}')
+
+# Match letters to integers
+_char_to_int = {}
+for k in string.ascii_uppercase:
+    _char_to_int[k] = str(ord(k) - 55)
+_char_to_int['+'] = '36'
+_char_to_int['*'] = '37'
 
 
 def compact(number):
@@ -53,16 +69,27 @@ def compact(number):
 
 
 def validate(number):
-    """Check if the number is a valid BTW number. This checks the length,
-    formatting and check digit."""
+    """Check if the number is a valid BTW number. Two possible checks:
+    - For natural persons
+    - For non-natural persons and combinations of natural persons (company)"""
     number = compact(number)
-    if not isdigits(number[10:]) or int(number[10:]) <= 0:
-        raise InvalidFormat()
     if len(number) != 12:
         raise InvalidLength()
-    if number[9] != 'B':
+    if not _btw_re.match(number):
         raise InvalidFormat()
-    bsn.validate(number[:9])
+
+    # Natural person => mod97 full checksum
+    check_val_natural = '2321'
+    for x in number:
+        check_val_natural += x if isdigits(x) else _char_to_int[x]
+    if int(check_val_natural) % 97 == 1:
+        return number
+
+    # Company => weighted(9->2) mod11 on bsn
+    if isdigits(number[:9]) and number[9] == 'B' and int(number[10:]) > 0:
+        bsn.validate(number[:9])
+    else:
+        raise InvalidFormat()
     return number
 
 

--- a/tests/test_eu_vat.doctest
+++ b/tests/test_eu_vat.doctest
@@ -581,6 +581,10 @@ These have been found online and should all be valid numbers.
 ... NL808373894B01
 ... NL811705262B01
 ... NL813411786B01
+... NL001162938B28
+... NL002455799B11
+... NL001617419B92
+... NL001452330B47
 ...
 ... PL 5211355116
 ... PL 5211754253


### PR DESCRIPTION
As of January 1st 2020, a new BTW identification number has been
introduced in Netherlands.

This commit implements the new check algorithm.

The algorithm detail can be found in:
http://kleineondernemer.nl/index.php/nieuw-btw-identificatienummer-vanaf-1-januari-2020-voor-eenmanszaken

Note that this implementation already takes into account the following:
> Op termijn kan de structuur met uitzondering van de landaanduiding op positie 1-2 en de 2 cijfers op positie 13-14 wijzigen.
Dat wil zeggen dat op de posities 3-12 cijfers, hoofdletters of de tekens ‘+’ en ‘*’ kunnen komen.

Even if positions 3-12 have still the format 9 digits + 'B', this might not be the case anymore in the future.

This aims to replace #183 and #184 