### PR TITLE
Add get_birth_date to no.fodselsnummer

### DIFF
--- a/stdnum/dk/cpr.py
+++ b/stdnum/dk/cpr.py
@@ -1,6 +1,7 @@
 # cpr.py - functions for handling Danish CPR numbers
 # coding: utf-8
 #
+# Copyright (C) 2020 Leon Sandøy
 # Copyright (C) 2012-2019 Arthur de Jong
 #
 # This library is free software; you can redistribute it and/or

--- a/stdnum/dk/cpr.py
+++ b/stdnum/dk/cpr.py
@@ -1,4 +1,5 @@
 # cpr.py - functions for handling Danish CPR numbers
+# coding: utf-8
 #
 # Copyright (C) 2012-2019 Arthur de Jong
 #
@@ -44,10 +45,12 @@ More information:
 Traceback (most recent call last):
     ...
 InvalidComponent: ...
+>>> validate("2110525629")
+Traceback (most recent call last):
+  ...
+InvalidComponent: The birth date information is valid, but this person has not been born yet.
 >>> get_birth_date('2110620629')
 datetime.date(1962, 10, 21)
->>> get_birth_date('2110525629')
-datetime.date(2052, 10, 21)
 >>> format('2110625629')
 '211062-5629'
 """
@@ -86,7 +89,7 @@ def get_birth_date(number):
     try:
         return datetime.date(year, month, day)
     except ValueError:
-        raise InvalidComponent()
+        raise InvalidComponent('The number does not contain valid birth date information.')
 
 
 def validate(number):
@@ -97,9 +100,14 @@ def validate(number):
         raise InvalidFormat()
     if len(number) != 10:
         raise InvalidLength()
-    # check if birth date is valid
-    get_birth_date(number)
-    # TODO: check that the birth date is not in the future
+
+    # Check if birth date is valid, and in the past
+    birth_date = get_birth_date(number)
+    if birth_date > datetime.date.today():
+        raise InvalidComponent(
+            'The birth date information is valid, but this person has not been born yet.',
+        )
+
     return number
 
 

--- a/stdnum/no/fodselsnummer.py
+++ b/stdnum/no/fodselsnummer.py
@@ -30,16 +30,16 @@ More information:
 * https://no.wikipedia.org/wiki/F%C3%B8dselsnummer
 * https://en.wikipedia.org/wiki/National_identification_number#Norway
 
->>> validate('684131 52112')
-'68413152112'
->>> get_gender('684131 52112')
-'M'
->>> validate('684131 52123')
+>>> validate('151086 95088')
+'15108695088'
+>>> get_gender('151086-95088')
+'F'
+>>> validate('15108695077')
 Traceback (most recent call last):
     ...
 InvalidChecksum: ...
->>> format('68413152112')
-'684131 52112'
+>>> format('15108695077')
+'151086 95077'
 """
 import datetime
 

--- a/stdnum/no/fodselsnummer.py
+++ b/stdnum/no/fodselsnummer.py
@@ -1,6 +1,7 @@
 # fodselsnummer.py - functions for handling Norwegian birth numbers
 # coding: utf-8
 #
+# Copyright (C) 2020 Leon Sandøy
 # Copyright (C) 2018 Ilya Vihtinsky
 # Copyright (C) 2018 Arthur de Jong
 #
@@ -40,6 +41,7 @@ InvalidChecksum: ...
 >>> format('68413152112')
 '684131 52112'
 """
+import datetime
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -72,6 +74,49 @@ def get_gender(number):
         return 'F'
 
 
+def get_birth_date(number):
+    """Determine and return the birth date."""
+    number = compact(number)
+    day = int(number[0:2])
+    month = int(number[2:4])
+    year = int(number[4:6])
+
+    individual_digits = int(number[6:9])
+
+    # Raise a more useful exception for FH numbers
+    if day >= 80:
+        raise InvalidComponent(
+            'This number is an FH-number, and does not contain birth date information by design.',
+        )
+
+    # Correct the birth day for D-numbers. These have a modified first digit.
+    # https://no.wikipedia.org/wiki/F%C3%B8dselsnummer#D-nummer
+    if day > 40:
+        day -= 40
+
+    # Correct the birth month for H-numbers. These have a modified third digit.
+    # https://no.wikipedia.org/wiki/F%C3%B8dselsnummer#H-nummer
+    if month > 40:
+        month -= 40
+
+    if individual_digits < 500:
+        year += 1900
+    elif 500 <= individual_digits < 750 and year >= 54:
+        year += 1800
+    elif 500 <= individual_digits < 1000 and year < 40:
+        year += 2000
+    elif 900 <= individual_digits < 1000 and year >= 40:
+        year += 1900
+    # The birth century falls outside all defined ranges.
+    else:
+        raise InvalidComponent('The birthdate century cannot be determined')
+
+    try:
+        return datetime.date(year, month, day)
+    except ValueError:
+        raise InvalidComponent('The number does not contain valid birth date information.')
+
+
 def validate(number):
     """Check if the number is a valid birth number."""
     number = compact(number)
@@ -83,6 +128,13 @@ def validate(number):
         raise InvalidChecksum()
     if number[-1] != calc_check_digit2(number):
         raise InvalidChecksum()
+
+    # Check if birth date is valid, and in the past
+    birth_date = get_birth_date(number)
+    if birth_date > datetime.date.today():
+        raise InvalidComponent(
+            'The birth date information is valid, but this person has not been born yet.',
+        )
     return number
 
 

--- a/stdnum/se/personnummer.py
+++ b/stdnum/se/personnummer.py
@@ -63,10 +63,13 @@ def compact(number):
 
 
 def get_birth_date(number):
-    """Guess the birth date from the number.
+    """Determine the birth date from the number.
 
-    Note that it may be 100 years off because the number has only the last
-    two digits of the year."""
+    For people aged 100 and up, the minus/dash in the personnummer is changed to a plus
+    on New Year's Eve the year they turn 100.
+
+    See Folkbokföringslagen (1991:481), §18.
+    """
     number = compact(number)
     if len(number) == 13:
         year = int(number[0:4])

--- a/stdnum/se/personnummer.py
+++ b/stdnum/se/personnummer.py
@@ -1,6 +1,7 @@
 # personnummer.py - functions for handling Swedish Personal identity numbers
 # coding: utf-8
 #
+# Copyright (C) 2020 Leon Sandøy
 # Copyright (C) 2018 Ilya Vihtinsky
 # Copyright (C) 2018 Arthur de Jong
 #

--- a/tests/test_no_fodselsnummer.doctest
+++ b/tests/test_no_fodselsnummer.doctest
@@ -1,5 +1,6 @@
 test_no_fodselsnummer.doctest - more detailed doctests for stdnum.no.fodselsnummer module
 
+Copyright (C) 2020 Leon Sandøy
 Copyright (C) 2018 Ilya Vihtinsky
 Copyright (C) 2018 Arthur de Jong
 

--- a/tests/test_no_fodselsnummer.doctest
+++ b/tests/test_no_fodselsnummer.doctest
@@ -41,13 +41,13 @@ These numbers should be detected as male or female.
 
 The last two check digits are validated independently of each other.
 
->>> fodselsnummer.is_valid('42485176432')
+>>> fodselsnummer.is_valid('26111593816')
 True
->>> fodselsnummer.is_valid('42485176431')  # only change last digit
+>>> fodselsnummer.is_valid('26111593817')  # only change last digit
 False
->>> fodselsnummer.is_valid('42485176412')  # only change first digit
+>>> fodselsnummer.is_valid('26111593826')  # only change first digit
 False
->>> fodselsnummer.is_valid('42485176416')  # change first, correct second
+>>> fodselsnummer.is_valid('26111593875')  # change first, correct second
 False
 
 
@@ -63,51 +63,52 @@ Traceback (most recent call last):
 InvalidFormat: ...
 
 
-These have been found online and should all be valid numbers.
+The birth date can be extracted from the number:
 
->>> numbers = '''
-...
-... 11027794191
-... 11051996811
-... 19575770838
-... 21918484865
-... 24396859900
-... 27213364885
-... 27389446152
-... 30383131118
-... 30777674125
-... 31042639152
-... 34831582121
-... 39043009846
-... 40070897972
-... 40673759612
-... 42115114470
-... 42485176432
-... 42957044500
-... 44207789809
-... 45014054018
-... 46929323343
-... 50067834221
-... 56403643756
-... 56653047547
-... 63282310041
-... 68413152112
-... 70031073454
-... 70341666064
-... 70624830529
-... 71494457037
-... 71946503120
-... 75442702381
-... 79189404641
-... 79318270827
-... 82938389280
-... 83814827871
-... 89829529360
-... 92782833709
-... 95700625908
-... 96517753502
-... 98576936818
-...
-... '''
->>> [x for x in numbers.splitlines() if x and not fodselsnummer.is_valid(x)]
+>>> fodselsnummer.get_birth_date('11111598403')
+datetime.date(2015, 11, 11)
+>>> fodselsnummer.get_birth_date('151086-95088')
+datetime.date(1986, 10, 15)
+>>> fodselsnummer.get_birth_date('180615 92527')
+datetime.date(2015, 6, 18)
+>>> fodselsnummer.get_birth_date('10 04 87 44 732')
+datetime.date(1987, 4, 10)
+>>> fodselsnummer.get_birth_date('13-04-99-58441')
+datetime.date(1899, 4, 13)
+
+Invalid dates are rejected:
+
+>>> fodselsnummer.validate("19575770838")
+Traceback (most recent call last):
+  ...
+InvalidComponent: The number does not contain valid birth date information.
+>>> fodselsnummer.get_birth_date("45014054018")
+Traceback (most recent call last):
+  ...
+InvalidComponent: The birthdate century cannot be determined
+>>> fodselsnummer.get_birth_date('82314251342')
+Traceback (most recent call last):
+  ...
+InvalidComponent: This number is an FH-number, and does not contain birth date information by design.
+>>> fodselsnummer.validate("19102270846")
+Traceback (most recent call last):
+	...
+InvalidComponent: The birth date information is valid, but this person has not been born yet.
+
+Here is a series of valid fødselsnummer:
+>>> numbers = [
+... '18-06-15-92527',
+... '26111594448',
+... '26111594286',
+... '26 11 15 940 14',
+... '26111593816',
+... '111115984-03',
+... '23114048690',
+... '231140-38547',
+... '100487 45526',
+... '10048745364',
+... '10048744732',
+... '151086-95088',
+... ]
+>>> [num for num in numbers if not fodselsnummer.is_valid(num)]
 []


### PR DESCRIPTION
This PR adds the ability to get the birth date from a Norwegian fødselsnummer, and also makes minor changes to the Swedish and Danish personal identity numbers (which share many similarities) in order to improve consistency between these three files.

This has the side effect of making validation of all three of these personal identity numbers stricter than it was before, because the validator will now check that the birth date is valid. This appears to be a fairly established convention in the repository already, and makes the validator far more precise.

## Changes
- Improved an outdated docstring in `se.personnummer.get_birth_date`
- Implemented `no.fodselsnummer.get_birth_date`
- Changed the `no.fodselsnummer.validate` validator to account for birth dates.
- ~~Added a check in `se.personnummer.validate` to make sure the birth date is not a future date.~~
- Added a check in `dk.cpr.validate` to make sure the birth date is not a future date. This resolved a TODO from this file.
- Added attribution according to established norm in the rest of the repo.
- Added documentation with examples of new functionality, and updated some documentation (the validators) that was no longer accurate.