### PR TITLE
Optional parameter for allowing temporary range individual numbers

### DIFF
--- a/stdnum/fi/hetu.py
+++ b/stdnum/fi/hetu.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2011 Jussi Judin
 # Copyright (C) 2012, 2013 Arthur de Jong
+# Copyright (C) 2020 Aleksi Hoffman
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -71,9 +72,12 @@ def _calc_checksum(number):
     return '0123456789ABCDEFHJKLMNPRSTUVWXY'[int(number) % 31]
 
 
-def validate(number):
+def validate(number, allow_temporary=False):
     """Check if the number is a valid HETU. It checks the format, whether a
-    valid date is given and whether the check digit is correct."""
+    valid date is given and whether the check digit is correct. Allows
+    temporary identifier range for individuals (902-999) if allow_temporary
+    is True.
+    """
     number = compact(number)
     match = _hetu_re.search(number)
     if not match:
@@ -92,7 +96,7 @@ def validate(number):
     if individual < 2:
         raise InvalidComponent()
     # this range is for temporary identifiers
-    if 900 <= individual <= 999:
+    if 900 <= individual <= 999 and not allow_temporary:
         raise InvalidComponent()
     checkable_number = '%02d%02d%02d%03d' % (day, month, year, individual)
     if match.group('control') != _calc_checksum(checkable_number):

--- a/stdnum/fi/hetu.py
+++ b/stdnum/fi/hetu.py
@@ -75,7 +75,7 @@ def _calc_checksum(number):
 def validate(number, allow_temporary=False):
     """Check if the number is a valid HETU. It checks the format, whether a
     valid date is given and whether the check digit is correct. Allows
-    temporary identifier range for individuals (902-999) if allow_temporary
+    temporary identifier range for individuals (900-999) if allow_temporary
     is True.
     """
     number = compact(number)

--- a/tests/test_fi_hetu.doctest
+++ b/tests/test_fi_hetu.doctest
@@ -2,6 +2,7 @@ test_fi_hetu.doctest - more detailed doctests for stdnum.fi.hetu module
 
 Copyright (C) 2011 Jussi Judin
 Copyright (C) 2013 Arthur de Jong
+Copyright (C) 2020 Aleksi Hoffman
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -31,10 +32,13 @@ Normal values that should just work.
 
 >>> hetu.validate('131052-308T')
 '131052-308T'
+
 >>> hetu.validate('131052+308T')
 '131052+308T'
+
 >>> hetu.validate('131052A308T')
 '131052A308T'
+
 >>> hetu.validate('131052a308t')
 '131052A308T'
 
@@ -53,6 +57,7 @@ Invalid century indicator:
 Traceback (most recent call last):
     ...
 InvalidFormat: ...
+
 >>> hetu.validate('131052T308T')
 Traceback (most recent call last):
     ...
@@ -65,6 +70,7 @@ Invalid birth date:
 Traceback (most recent call last):
     ...
 InvalidComponent: ...
+
 >>> hetu.validate('130052-308R')
 Traceback (most recent call last):
     ...
@@ -79,19 +85,27 @@ InvalidFormat: ...
 
 
 Invalid individual number: (for historical reasons individual IDs start from
-002 and the range from 900 to 999 is used as temporary identifiers)
+002 and the range from 900 to 999 is used as temporary identifiers). Temporary range
+individual number should be allowed when the allow_temporary parameter is set to True.
 
 >>> hetu.validate('131052-000V')
 Traceback (most recent call last):
     ...
 InvalidComponent: ...
+
 >>> hetu.validate('131052-9993')
 Traceback (most recent call last):
     ...
 InvalidComponent: ...
 
+>>> hetu.validate('131052-9993', allow_temporary=True)
+'131052-9993'
+
 
 compact() and format() don't do much special:
 
 >>> hetu.compact('131052a308t')
+'131052A308T'
+
+>>> hetu.format('131052a308t')
 '131052A308T'


### PR DESCRIPTION
There are valid use cases for the temporary range individual numbers - this PR adds validating  temporary range individual numbers possible with an optional parameter.

The validate function raises `InvalidComponent` for temporary range individual numbers by default as before.