### PR TITLE
Expanded validation for BE VAT numbers

### DIFF
--- a/stdnum/be/vat.py
+++ b/stdnum/be/vat.py
@@ -61,7 +61,7 @@ def validate(number):
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
-    if not isdigits(number):
+    if not isdigits(number) or int(compact(number)) <= 0:
         raise InvalidFormat()
     if len(number) != 10:
         raise InvalidLength()


### PR DESCRIPTION
Specifically invalidated all-zero numbers

BE0000000000 would previously result in a valid VAT number