### PR TITLE
Add support for XI VAT numbers in vatin

### DIFF
--- a/stdnum/vatin.py
+++ b/stdnum/vatin.py
@@ -61,6 +61,8 @@ def _get_cc_module(cc):
     """Get the VAT number module based on the country code."""
     # Greece uses a "wrong" country code
     cc = cc.lower().replace('el', 'gr')
+    # Special case for Northern Ireland
+    cc = cc.lower().replace('xi', 'gb')
     if not re.match(r'^[a-z]{2}$', cc):
         raise InvalidFormat()
     if cc not in _country_modules:


### PR DESCRIPTION
XI VAT numbers now works well via stdnum.gb.vat, but not via stdnum.vatin
This PR fixes it.
I'm not familiar with the code, so check carefully.
More info on #250 