### PR TITLE
Add support for Thailand Number

### DIFF
--- a/stdnum/th/__init__.py
+++ b/stdnum/th/__init__.py
@@ -1,0 +1,21 @@
+# __init__.py - collection of Thai numbers
+# coding: utf-8
+#
+# Copyright (C) 2021 Piruin Panichphol
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Collection of Thai numbers."""

--- a/stdnum/th/moa.py
+++ b/stdnum/th/moa.py
@@ -1,0 +1,100 @@
+# moa.py - functions for handling Memorandum of Association Number
+#
+# Copyright (C) 2021 Piruin Panichphol
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""MOA (Thailand Memorandum of Association Number).
+
+Memorandum of Association Number (aka Company's Taxpayer Identification
+Number) are numbers issued by the Department of Bussiness Development.
+This number consists of 13 digits which the last is a check digit follow
+the Personal Identity Number (PIN) standard. but with different grouping
+format and always start with zero to indicate that is 13 digits number
+issued by DBD. like 0-XX-X-XXX-XXXXX-X.
+
+Reference:
+* https://www.dbd.go.th/download/pdf_kc/s09/busin_2542-48.pdf
+
+>>> compact('0 10 5 536 11201 4')
+'0105536112014'
+>>> validate('0994000617721')
+'0994000617721'
+>>> validate('0-99-4-000-61772-1')
+'0994000617721'
+>>> validate('0-99-4-000-61772-3')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> format('0993000133978')
+'0-99-3-000-13397-8'
+"""
+
+from stdnum.exceptions import *
+from stdnum.util import clean, isdigits
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    return clean(number, ' -').strip()
+
+
+def calc_check_digit(number):
+    """Calculate the check digit."""
+    x = sum([(13 - i) * int(number[i]) for i in range(12)]) % 11
+    return str((11 - x) % 10)
+
+
+def validate(number):
+    """
+    Check if the number is a valid MOA Number.
+    This checks the length, formatting, component and check digit.
+    """
+    number = compact(number)
+    if len(number) != 13:
+        raise InvalidLength()
+    if not isdigits(number):
+        raise InvalidFormat()
+    if number[0] != '0':
+        raise InvalidComponent()
+    if number[-1] != calc_check_digit(number):
+        raise InvalidChecksum()
+    return number
+
+
+def is_valid(number):
+    """Check whether number is valid."""
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False
+
+
+def format(number):
+    """Reformat the number to the standard presentation format."""
+    if len(number) == 13:
+        number = '-'.join(
+            (
+                number[:1],
+                number[1:3],
+                number[3:4],
+                number[4:7],
+                number[7:12],
+                number[12],
+            ),
+        )
+    return number

--- a/stdnum/th/pin.py
+++ b/stdnum/th/pin.py
@@ -1,0 +1,95 @@
+# pin.py - functions for handling PINs
+#
+# Copyright (C) 2021 Piruin Panichphol
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""PIN (Thailand Personal Identification Number).
+
+The Thailand Personal Identification Number is a unique personal
+identifier assigned at birth or upon receiving Thai citizenship
+issue by the Ministry of Interior.
+
+This number consists of 13 digits which the last is a check digit.
+Usually separated into five groups using hyphens to make it easier
+to read, like X-XXXXX-XXXXX-XX-X.
+
+More Information:
+* https://en.wikipedia.org/wiki/Thai_identity_card
+
+>>> compact('1-2345-45678-78-1')
+'1234545678781'
+>>> validate('3100600445635')
+'3100600445635'
+>>> validate('1-2345-45678-78-1')
+'1234545678781'
+>>> validate('1-2345-45678-78-9')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> format('7100600445635')
+'7-1006-00445-63-5'
+>>> format('7100600445')
+'7100600445'
+
+"""
+
+from stdnum.exceptions import *
+from stdnum.util import clean, isdigits
+
+
+def compact(number):
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    return clean(number, ' -').strip()
+
+
+def calc_check_digit(number):
+    """Calculate the check digit."""
+    x = sum([(13 - i) * int(number[i]) for i in range(12)]) % 11
+    return str((11 - x) % 10)
+
+
+def validate(number):
+    """Check if the number is a valid PIN. This checks the length,
+    formatting and check digit."""
+    number = compact(number)
+    if len(number) != 13:
+        raise InvalidLength()
+    if not isdigits(number):
+        raise InvalidFormat()
+    if number[0] in ('0', '9'):
+        raise InvalidComponent()
+    if number[-1] != calc_check_digit(number):
+        raise InvalidChecksum()
+    return number
+
+
+def is_valid(number):
+    """Check whether the check digit is valid."""
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False
+
+
+def format(number):
+    """Reformat the number to the standard presentation format."""
+    if len(number) == 13:
+        number = '-'.join(
+            (number[:1], number[1:5], number[5:10], number[10:12], number[12]),
+        )
+    return number

--- a/stdnum/th/tin.py
+++ b/stdnum/th/tin.py
@@ -1,6 +1,7 @@
-# tin.py - functions for handling TINs
+# tin.py - functions for handling Thailand TINs
 #
-# Copyright (C) 2013 Arthur de Jong
+# Copyright (C) 2021 Piruin Panichphol
+# Copyright (C) 2013 Arthur de Jong - stdnum/us/tin.py
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,49 +18,49 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-"""TIN (U.S. Taxpayer Identification Number).
+"""TIN (Thailand Taxpayer Identification Number).
 
-The Taxpayer Identification Number is used used for tax purposes in the
-United Si:wqtates. A TIN may be:
+The Taxpayer Identification Number is used for tax purposes in the
+Thailand. This number consists of 13 digits which the last is a check
+digit.
 
-* a Social Security Number (SSN)
-* an Individual Taxpayer Identification Number (ITIN)
-* an Employer Identification Number (EIN)
-* a Preparer Tax Identification Number (PTIN)
-* an Adoption Taxpayer Identification Number (ATIN)
+Personal income taxpayers use Personal Identification Number (PIN)
+as their TIN. While companies use Memorandum of Association (MOA) as
+their TIN
 
->>> compact('123-45-6789')
-'123456789'
->>> validate('123-45-6789')
-'123456789'
->>> validate('07-3456789')
+>>> compact('0 10 5 536 11201 4')
+'0105536112014'
+>>> validate('1-2345-45678-78-1')
+'1234545678781'
+>>> validate('0-99-4-000-61772-1')
+'0994000617721'
+>>> validate('1234545678789')
 Traceback (most recent call last):
     ...
 InvalidFormat: ...
->>> guess_type('536-90-4399')
-['ssn', 'atin']
->>> guess_type('04-2103594')
-['ein']
->>> guess_type('042103594')
-['ssn', 'ein', 'atin']
->>> format('042103594')
-'042-10-3594'
->>> format('123-456')  # invalid numbers are not reformatted
-'123-456'
+>>> check_type('1-2345-45678-78-1')
+'pin'
+>>> check_type('0-99-4-000-61772-1')
+'moa'
+>>> format('3100600445635')
+'3-1006-00445-63-5'
+>>> format('0993000133978')
+'0-99-3-000-13397-8'
+
 """
 
 from stdnum.exceptions import *
-from stdnum.us import atin, ein, itin, ptin, ssn
+from stdnum.th import moa, pin
 from stdnum.util import clean
 
 
-_tin_modules = (ssn, itin, ein, ptin, atin)
+_tin_modules = (moa, pin)
 
 
 def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
-    return clean(number, '-').strip()
+    return clean(number, ' -').strip()
 
 
 def validate(number):
@@ -82,12 +83,13 @@ def is_valid(number):
         return False
 
 
-def guess_type(number):
-    """Return a list of possible TIN types for which this number is
-    valid.."""
-    return [mod.__name__.rsplit('.', 1)[-1]
-            for mod in _tin_modules
-            if mod.is_valid(number)]
+def check_type(number):
+    """Return a TIN type which this number is valid."""
+    for mod in _tin_modules:
+        if mod.is_valid(number):
+            return mod.__name__.rsplit('.', 1)[-1]
+    # fallback
+    return None
 
 
 def format(number):

--- a/stdnum/th/tin.py
+++ b/stdnum/th/tin.py
@@ -1,7 +1,6 @@
 # tin.py - functions for handling Thailand TINs
 #
 # Copyright (C) 2021 Piruin Panichphol
-# Copyright (C) 2013 Arthur de Jong - stdnum/us/tin.py
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/stdnum/us/tin.py
+++ b/stdnum/us/tin.py
@@ -20,7 +20,7 @@
 """TIN (U.S. Taxpayer Identification Number).
 
 The Taxpayer Identification Number is used used for tax purposes in the
-United Si:wqtates. A TIN may be:
+United States. A TIN may be:
 
 * a Social Security Number (SSN)
 * an Individual Taxpayer Identification Number (ITIN)

--- a/tests/test_th_moa.doctest
+++ b/tests/test_th_moa.doctest
@@ -1,0 +1,84 @@
+test_th_mod.doctest - more detailed doctests for stdnum.th.moa module
+
+Copyright (C) 2021 Piruin Panichphol
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.th.moa module.
+
+>>> from stdnum.th import moa
+
+>>> moa.validate('0-99-4-000')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> moa.validate('0-99-4-00A-61772-X')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> moa.validate('3-99-4-000-61772-1')
+Traceback (most recent call last):
+    ...
+InvalidComponent: ...
+>>> moa.validate('0-99-4-000-61772-8')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> moa.format('0-99-4-000') # Not format
+'0-99-4-000'
+
+These have been found online and should all be valid numbers.
+https://vsreg.rd.go.th/VATINFOWSWeb/jsp/VATInfoWSServlet?
+
+>>> numbers = '''
+...
+... 0745554003056
+... 0105542067556
+... 0713551000259
+... 0115555008901
+... 0992001526719
+... 0105530041751
+... 0655554000295
+... 0115556023301
+... 0992001001446
+... 0105556000751
+... 0992001158728
+... 0105549020393
+... 0105543014758
+... 0105543014758
+... 0245541000066
+... 0105554084159
+... 0105556142792
+... 0-10-5-518-00189-3
+... 0-10-5-539-13697-6
+... 0-10-5-554-04636-2
+... 0-99-2-002-50289-9
+... 0-10-3-541-01737-5
+... 0 10 5 559 13643 2
+... 0 12 5 551 01213 1
+... 0 22 5 550 00051 1
+... 0 10 5 560 07360 1
+... 0 19 5 554 00071 1
+... 0 10 5 544 04660 2
+... 0 1055 43000 15 3
+... 0-7035-36000-78-2
+... 01055  6302 15 4 7
+... 05  0  55440 03519
+...
+... '''
+>>> [x for x in numbers.splitlines() if x and not moa.is_valid(x)]
+[]

--- a/tests/test_th_pin.doctest
+++ b/tests/test_th_pin.doctest
@@ -1,0 +1,95 @@
+test_th_pin.doctest - more detailed doctests for stdnum.th.pin module
+
+Copyright (C) 2021 Piruin Panichphol
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.th.pin module.
+
+>>> from stdnum.th import pin
+
+>>> pin.validate('1-2345-45678-78-11')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> pin.validate('1-2345-45678-78-X')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> pin.validate('0-2345-45678-78-1')
+Traceback (most recent call last):
+    ...
+InvalidComponent: ...
+>>> pin.validate('9-2345-45678-78-1')
+Traceback (most recent call last):
+    ...
+InvalidComponent: ...
+
+
+These have been found online and should all be valid numbers.
+
+>>> numbers = '''
+...
+... 3810100438722
+... 3100400648338
+... 3101900254691
+... 3102400746269
+... 5900599008311
+... 3540200423193
+... 3600500113229
+... 1311100161266
+... 5671000003006
+... 3709800221741
+... 3569900168313
+... 3400100399577
+... 4220100005137
+... 1459900065632
+... 1670800079267
+... 3629900162691
+... 5260399000878
+... 1100900359657
+... 1350500075722
+... 5100200233319
+... 3 6710 00129 65 8
+... 5 5805 90000 01 9
+... 5 3013 00038 01 1
+... 1 7399 00504 82 0
+... 1 1996 00076 67 4
+... 1 1101 00152 64 1
+... 3 5099 00736 90 7
+... 2 3107 00002 24 7
+... 1 6299 00299 92 5
+... 3 7401 00523 48 8
+... 1-1002-00439-84-4
+... 3-3207-00476-55-7
+... 3-7005-00702-40-1
+... 3-5207-00211-03-9
+... 3-1103-00283-26-5
+... 4-6607-00003-53-1
+... 3-1898-00009-58-6
+... 3-6599-00381-54-7
+... 3-9099-00588-10-6
+... 3-1001-00818-95-5
+... 4 6205000  0482 7
+... 3  91 05 00  3    92 03 6
+... 3  3415  01 082 5 68
+... 3   451  000  50     5414
+... 33508 0030 2577
+...
+... '''
+>>> [x for x in numbers.splitlines() if x and not pin.is_valid(x)]
+[]

--- a/tests/test_th_tin.doctest
+++ b/tests/test_th_tin.doctest
@@ -1,0 +1,94 @@
+test_th_tin.doctest - more detailed doctests for stdnum.th.tin module
+
+Copyright (C) 2021 Piruin Panichphol
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.th.tin module.
+
+>>> from stdnum.th import tin
+
+>>> tin.validate('1-2345-45678-78-11') # InvalidLength
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> tin.validate('1-2345-45678-78-X') # InvalidFormat
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> tin.validate('0-2345-45678-78-1') # InvalidChecksum
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> tin.validate('9-2345-45678-78-1') # InvalidComponent
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> tin.format('0234545678783')
+'0-23-4-545-67878-3'
+>>> tin.format('0234545678781') # Not format invalid number
+'0234545678781'
+>>> tin.check_type('0234545678783')
+'moa'
+>>> tin.check_type('0234545678780')  # Invalid number return None
+
+
+These have been found online and should all be valid numbers.
+
+>>> numbers = '''
+...
+... 0105552029681
+... 0343559002742
+... 0105559074461
+... 0105559074461
+... 0403552000484
+... 0835561014091
+... 0 13 5 559 01262 8
+... 0 74 5 561 00276 1
+... 0 74 5 561 00276 1
+... 0 55 3 561 00041 5
+... 0 20 5 560 00584 1
+... 0-33-3-558-00060-6
+... 0-47-5-562-00062-4
+... 0-58-3-558-00012-4
+... 0-73-5-561-00588-3
+... 0-11-5-561-01623-6
+... 0-2055-61011-25-0
+... 0-3035-50001-80-8
+... 0-2155-51001-61-8
+... 0-7355-56003-30-4
+... 1129900166199
+... 1509900258294
+... 1939990003289
+... 8 4799 88011 44 1
+... 3 5099 01429 67 6
+... 1 3501 00018 05 5
+... 1 1020 01865 33 1
+... 3 2001 00052 57 9
+... 3-1907-00075-74-1
+... 1-4701-00062-82-7
+... 1-8399-00112-47-5
+... 1-6707-00016-13-1
+... 1-40-9-900-07433-0
+... 1-56-0-300-01581-3
+... 2-30-9-900-00391-1
+... 3-10-1-201-21325-1
+... 5-49-0-200-01960-8
+...
+... '''
+>>> [x for x in numbers.splitlines() if x and not tin.is_valid(x)]
+[]


### PR DESCRIPTION
This PR Included
- TIN Taxpayer Identification Number #118
- PIN Personal Identification Number
- MOA Memorandum of Association Number

TIN is a reference to PIN for Personal taxpayers and MOA for companies. both are 13 digits which the last is a check digit  
You can check how to calculate checksum at [Wikipedia:เลขประจำตัวประชาชนไทย](https://th.wikipedia.org/wiki/%E0%B9%80%E0%B8%A5%E0%B8%82%E0%B8%9B%E0%B8%A3%E0%B8%B0%E0%B8%88%E0%B8%B3%E0%B8%95%E0%B8%B1%E0%B8%A7%E0%B8%9B%E0%B8%A3%E0%B8%B0%E0%B8%8A%E0%B8%B2%E0%B8%8A%E0%B8%99%E0%B9%84%E0%B8%97%E0%B8%A2) (Sorry, Not found any translated document online)