### PR TITLE
Add ISRC (International Standard Recording Code)

### DIFF
--- a/README
+++ b/README
@@ -127,6 +127,7 @@ Currently this package supports the following formats:
  * ISIL (International Standard Identifier for Libraries)
  * ISIN (International Securities Identification Number)
  * ISMN (International Standard Music Number)
+ * ISRC (International Standard Recording Code)
  * ISO 11649 (Structured Creditor Reference)
  * ISO 6346 (International standard for container identification)
  * ISSN (International Standard Serial Number)

--- a/docs/stdnum.isrc.rst
+++ b/docs/stdnum.isrc.rst
@@ -1,0 +1,5 @@
+stdnum.isrc
+===========
+
+.. automodule:: stdnum.isrc
+   :members:

--- a/stdnum/isrc.py
+++ b/stdnum/isrc.py
@@ -1,0 +1,83 @@
+# isrc.py - functions for International Standard Recording Codes (ISRC)
+#
+# Copyright (C) 2021 Nuno André Novo
+# Copyright (C) 2014-2021 Arthur de Jong
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""ISRC (International Standard Recording Code).
+
+The ISRC is an international standard code (ISO 3901) for uniquely
+identifying sound recordings and music video recordings.
+
+More information:
+
+* https://en.wikipedia.org/wiki/International_Standard_Recording_Code
+"""
+
+from stdnum.exceptions import *
+from stdnum.util import clean, segment
+from stdnum.isin import _iso_3116_1_country_codes
+from string import ascii_uppercase, digits
+
+
+# These special codes are allowed for ISRC
+_country_codes = set(_iso_3116_1_country_codes + [
+    'QM',  # US new registrants due to US codes became exhausted
+    'CP',  # reserved for further overflow
+    'DG',  # idem
+    'ZZ',  # International ISRC Agency codes
+])
+
+_chunks = 2, 3, 2, 5
+
+
+def compact(number):
+    """Convert the ISRC to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+    return clean(number, ' -').strip().upper()
+
+
+def validate(number):
+    """Check if the number provided is a valid ISRC. This checks the length,
+    the alphabet, and the country code but does not check if the registrant
+    code is known."""
+    number = compact(number)
+    country, registrant, year, record = segment(number, *_chunks)
+
+    if len(number) != 12:
+        raise InvalidLength()
+    if any(c not in ascii_uppercase + digits for c in registrant):
+        raise InvalidFormat()
+    if any(c not in digits for c in year + record):
+        raise InvalidFormat()
+    if country not in _country_codes:
+        raise InvalidComponent()
+
+    return number
+
+
+def is_valid(number):
+    try:
+        return bool(validate(number))
+    except ValidationError:
+        return False
+
+
+def format(number, separator='-'):
+    """Reformat the number to the common representation."""
+    parts = segment(compact(number), *_chunks)
+    return separator.join(parts)

--- a/stdnum/util.py
+++ b/stdnum/util.py
@@ -200,6 +200,19 @@ def to_unicode(text):
     return text
 
 
+def segment(string, *sizes, start=0):
+    """Split the string into the indicated number and size of pieces.
+
+    >>> segment('0123456789ABCDEF', 3, 4, 5, 4)
+    ['012', '3456', '789AB', 'CDEF']
+    """
+    from itertools import accumulate, tee
+
+    a, b = tee(accumulate((start, *sizes)))
+    next(b, None)
+    return [string[slice(*ab)] for ab in zip(a, b)]
+
+
 def get_number_modules(base='stdnum'):
     """Yield all the number validation modules under the specified module."""
     __import__(base)

--- a/tests/test_isrc.doctest
+++ b/tests/test_isrc.doctest
@@ -1,0 +1,58 @@
+test_isrc.doctest - more detailed doctests for stdnum.isrc module
+
+Copyright (C) 2021 Nuno André Novo
+Copyright (C) 2010-2021 Arthur de Jong
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA
+
+
+This file contains more detailed doctests for the stdnum.isrc module. It
+tries to test more corner cases and detailed functionality that is not
+really useful as module documentation.
+
+>>> from stdnum import isrc
+
+
+These are normal variations that should just work.
+
+>>> isrc.validate('US-SKG-19-12345')
+'USSKG1912345'
+>>> isrc.validate('USSKG1912345')
+'USSKG1912345'
+>>> isrc.validate('us-skg1912345')
+'USSKG1912345'
+
+
+Tests for mangling and incorrect country codes.
+
+>>> isrc.validate('US-SKG-19-123456')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> isrc.validate('US-SKG-19-1234*')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> isrc.validate('XX-SKG-19-12345')
+Traceback (most recent call last):
+    ...
+InvalidComponent: ...
+
+
+Regrouping tests.
+
+>>> isrc.format('USSKG1912345')
+'US-SKG-19-12345'


### PR DESCRIPTION
Hi!

This PR adds support for the [ISRC (International Standard Recording Code)](https://en.wikipedia.org/wiki/International_Standard_Recording_Code).

I've also added a little function to `util.py` that I often use to split strings into different sizes. I think it could be useful for other codes. If you think that it's misplaced or misnamed I have no problem in modifying the commit.
```
>>> chunks = 3, 4, 5, 4
>>> segment('0123456789ABCDEF', *chunks)
['012', '3456', '789AB', 'CDEF']
```

Also, comment that I'm writing a wrapper to use _python-stdnum_ with _Pydantic_ ([_Pydentic_](https://github.com/nuno-andre/pydentic)). I have a little library with some validators for Pydantic models, and I've found that yours has almost all of them (and many more), so I think it's way more productive to add the missing ones to _python-stdnum_ and wrap it up. Currently, it is little more than a proof of concept but I will develop it in the next few days, and will also send some more PRs if you like.

Thanks for your work, it's really amazing. I wish I had known about it sooner :)
