### PR TITLE
Add new modules to stdnum.in_ and update existing ones

### DIFF
--- a/stdnum/in_/aadhaar.py
+++ b/stdnum/in_/aadhaar.py
@@ -24,24 +24,29 @@ Aadhaar is a 12 digit unique identity number issued to all Indian residents.
 The number is assigned by the Unique Identification Authority of India
 (UIDAI).
 
+Aadhaar is made up of 12 numeric characters, a unique 11 digit number and one
+check digit calculated using Verhoeff algorithm. The number is generated
+random, non-repeating sequence and does not begin with 0 or 1.
+
 More information:
 
 * https://en.wikipedia.org/wiki/Aadhaar
+* https://web.archive.org/web/20140611025606/http://uidai.gov.in/UID_PDF/Working_Papers/A_UID_Numbering_Scheme.pdf
 
 >>> validate('234123412346')
 '234123412346'
->>> validate('234123412347')
-Traceback (most recent call last):
-    ...
-InvalidChecksum: ...
->>> validate('123412341234')  # number should not start with 0 or 1
-Traceback (most recent call last):
-    ...
-InvalidFormat: ...
 >>> validate('643343121')
 Traceback (most recent call last):
     ...
 InvalidLength: ...
+>>> validate('123412341234')  # number should not start with 0 or 1
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> validate('234123412347')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
 >>> format('234123412346')
 '2341 2341 2346'
 >>> mask('234123412346')
@@ -94,8 +99,8 @@ def format(number: str) -> str:
 
 
 def mask(number: str) -> str:
-    """Masks the first 8 digits as per MeitY guidelines for securing identity
-    information and Sensitive personal data."""
+    """Masks the first 8 digits as per Ministry of Electronics and
+    Information Technology (MeitY) guidelines."""
 
     number = compact(number)
     return "XXXX XXXX " + number[-4:]

--- a/stdnum/in_/aadhaar.py
+++ b/stdnum/in_/aadhaar.py
@@ -1,6 +1,7 @@
 # aadhaar.py - functions for handling Indian Aadhaar numbers
 #
 # Copyright (C) 2017 Srikanth L
+# Copyright (C) 2021 Gaurav Chauhan
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -48,51 +49,53 @@ InvalidLength: ...
 """
 
 import re
+import stdnum.exceptions as e
 
 from stdnum import verhoeff
-from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-aadhaar_re = re.compile(r'^[2-9][0-9]{11}$')
-"""Regular expression used to check syntax of Aadhaar numbers."""
-
-
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
-    return clean(number, ' -').strip()
+
+    return clean(number, " -").strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
+
+    AADHAAR_RE = re.compile(r"^[2-9][0-9]{11}$")
     number = compact(number)
     if len(number) != 12:
-        raise InvalidLength()
-    if not aadhaar_re.match(number):
-        raise InvalidFormat()
+        raise e.InvalidLength()
+    if not AADHAAR_RE.match(number):
+        raise e.InvalidFormat()
     verhoeff.validate(number)
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
+
     try:
         return bool(validate(number))
-    except ValidationError:
+    except e.ValidationError:
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
+
     number = compact(number)
-    return ' '.join((number[:4], number[4:8], number[8:]))
+    return " ".join((number[:4], number[4:8], number[8:]))
 
 
-def mask(number):
+def mask(number: str) -> str:
     """Masks the first 8 digits as per MeitY guidelines for securing identity
     information and Sensitive personal data."""
+
     number = compact(number)
-    return 'XXXX XXXX ' + number[-4:]
+    return "XXXX XXXX " + number[-4:]

--- a/stdnum/in_/aadhaar.py
+++ b/stdnum/in_/aadhaar.py
@@ -64,14 +64,14 @@ from stdnum import verhoeff
 from stdnum.util import clean
 
 
-def compact(number: str) -> str:
+def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
     return clean(number, " -").strip()
 
 
-def validate(number: str) -> str:
+def validate(number):
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
 
@@ -87,7 +87,7 @@ def validate(number: str) -> str:
     return number
 
 
-def is_valid(number: str) -> bool:
+def is_valid(number):
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
 
@@ -97,14 +97,14 @@ def is_valid(number: str) -> bool:
         return False
 
 
-def format(number: str) -> str:
+def format(number):
     """Reformat the number to the standard presentation format."""
 
     number = compact(number)
     return " ".join((number[:4], number[4:8], number[8:]))
 
 
-def mask(number: str) -> str:
+def mask(number):
     """Masks the first 8 digits as per Ministry of Electronics and
     Information Technology (MeitY) guidelines."""
 

--- a/stdnum/in_/aadhaar.py
+++ b/stdnum/in_/aadhaar.py
@@ -43,6 +43,10 @@ InvalidLength: ...
 Traceback (most recent call last):
     ...
 InvalidFormat: ...
+>>> validate('222222222222')  # number cannot be a palindrome
+Traceback (most recent call last):
+    ...
+ValidationError: Invalid Aadhaar
 >>> validate('234123412347')
 Traceback (most recent call last):
     ...
@@ -77,6 +81,8 @@ def validate(number: str) -> str:
         raise e.InvalidLength()
     if not AADHAAR_RE.match(number):
         raise e.InvalidFormat()
+    if number == number[::-1]:  # to discard palindromes
+        raise e.ValidationError("Invalid Aadhaar")
     verhoeff.validate(number)
     return number
 

--- a/stdnum/in_/epic.py
+++ b/stdnum/in_/epic.py
@@ -59,14 +59,14 @@ from stdnum import luhn
 from stdnum.util import clean
 
 
-def compact(number: str) -> str:
+def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
     return clean(number, " -").upper().strip()
 
 
-def validate(number: str) -> str:
+def validate(number):
     """Check if the number provided is a valid EPIC number. This checks the
     length, formatting and checksum."""
 

--- a/stdnum/in_/epic.py
+++ b/stdnum/in_/epic.py
@@ -1,0 +1,90 @@
+# epic.py - functions for handling Indian EPIC number
+#
+# Copyright (C) 2021 Gaurav Chauhan
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""EPIC (Electoral Photo Identity Card, Indian Voter ID)
+
+The Electoral Photo Identity Card (EPIC) is an identity document issued by
+the Election Commission of India (ECI) to the citizens of India who have
+reached the age of 18.
+
+Each EPIC contains an unique 10 digit alphanumeric identifier known as EPIC
+number or Voter ID number. 
+
+Every EPIC number begins with a Functional Unique Serial Number (FUSN), a 3
+letter unique identifier for each Assembly Constituency. FUSN is followed by
+a 6 digit serial number and one check digit of the serial number calculated
+using Luhn algorithm.
+
+More information:
+
+* https://en.wikipedia.org/wiki/Voter_ID_(India)
+* https://www.kotaksecurities.com/ksweb/voter-id/serial-number-in-elctoral-roll
+
+>>> validate('WKH1186253')
+'WKH1186253'
+>>> validate('WKH118624')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> validate('1231186253')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> validate('WKH1186263')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+"""
+
+import re
+import stdnum.exceptions as e
+
+from stdnum import luhn
+from stdnum.util import clean
+
+
+def compact(number: str) -> str:
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+
+    return clean(number, " -").upper().strip()
+
+
+def validate(number: str) -> str:
+    """Check if the number provided is a valid EPIC number. This checks the
+    length, formatting and checksum."""
+
+    EPIC_RE = re.compile(r"^[A-Z]{3}[0-9]{7}$")
+    number = compact(number)
+    if len(number) != 10:
+        raise e.InvalidLength
+    if not EPIC_RE.match(number):
+        raise e.InvalidFormat()
+    luhn.validate(number[3:])
+    return number
+
+
+def is_valid(number: str) -> bool:
+    """Check if the number provided is a valid EPIC number. This checks the
+    length, formatting and checksum."""
+
+    try:
+        return bool(validate(number))
+    except e.ValidationError:
+        return False

--- a/stdnum/in_/gstin.py
+++ b/stdnum/in_/gstin.py
@@ -1,0 +1,161 @@
+# gstin.py - functions for handling Indian GST identification number
+#
+# Copyright (C) 2021 Gaurav Chauhan
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""GSTIN (Goods and Services Tax identification number, Indian VAT number).
+
+The Goods and Services Tax identification number (GSTIN) is a 15 digt unique
+identifier assigned to all tax paying entities in India registered under the
+Goods and Services Tax (GST) Act, 2017.
+
+Each GSTIN begins with a 2 digit State/Union Territory (UT) Code, as per 2011
+census, in the range 01 to 35. The next 10 characters are PAN of the holder.
+The 13th character is an alphanumeric digit that represents the number of
+GSTIN registrations made in a state/UT for same the PAN. Max. 35 registrations
+are allowed. The 14th character is "Z" by default. The last character is an
+alphanumeric check digit calculated using a custom algorithm.
+
+More information: 
+
+* https://bajajfinserv.in/insights/what-is-goods-and-service-tax-identification-number
+* https://en.wikipedia.org/wiki/Goods_and_Services_Tax_(India)
+
+>>> validate('27AAPFU0939F1ZV')
+'27AAPFU0939F1ZV'
+>>> validate('27AAPFU0939F1Z')
+Traceback (most recent call last):
+    ...
+InvalidLength: ...
+>>> validate('369296450896540')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> validate('36AAPFU0939F1ZV')    # invalid state code
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> validate('27AAPXU0939F1ZV')    # invalid PAN
+Traceback (most recent call last):
+    ...
+InvalidComponent: ...
+>>> validate('27AAPFU0939F1ZO')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+>>> info('27AAPFU0939F1ZV')['state_or_ut']
+'Maharashtra'
+"""
+
+import re
+import stdnum.exceptions as e
+
+from stdnum.in_ import pan, gstin_ca
+from stdnum.util import clean
+
+
+def compact(number: str) -> str:
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+
+    return clean(number, " -").upper().strip()
+
+
+def validate(number: str) -> str:
+    """Check if the number provided is a valid GSTIN. This checks the length,
+    formatting, embedded PAN and check digit."""
+
+    GSTIN_RE = re.compile(r"^[0-3][0-9][A-Z]{5}[0-9]{4}[A-Z][1-9A-Z][Z][0-9A-Z]$")
+    number = compact(number)
+    if len(number) != 15:
+        raise e.InvalidLength()
+    if not GSTIN_RE.match(number):
+        raise e.InvalidFormat()
+    if not 1 <= int(number[:2]) <= 35:
+        raise e.InvalidComponent()
+    pan.validate(number[2:12])
+    gstin_ca.validate(number)
+    return number
+
+
+def is_valid(number: str) -> bool:
+    """Check if the number provided is a valid GSTIN. This checks the length,
+    formatting, embedded PAN and check digit."""
+
+    try:
+        return bool(validate(number))
+    except e.ValidationError:
+        return False
+
+
+def info(number: str) -> dict[str, str, str, int]:
+    """Provide information that can be decoded locally from GSTIN (without
+    API).
+
+    More information can be viewed on the GST website. Search by:
+
+    * GSTIN: https://services.gst.gov.in/services/searchtp
+    * PAN: https://services.gst.gov.in/services/searchtpbypan
+    """
+
+    STATE_UT_CODES = {
+        "01": "Jammu and Kashmir",
+        "02": "Himachal Pradesh",
+        "03": "Punjab",
+        "04": "Chandigarh",
+        "05": "Uttarakhand",
+        "06": "Haryana",
+        "07": "Delhi",
+        "08": "Rajasthan",
+        "09": "Uttar Pradesh",
+        "10": "Bihar",
+        "11": "Sikkim",
+        "12": "Arunachal Pradesh",
+        "13": "Nagaland",
+        "14": "Manipur",
+        "15": "Mizoram",
+        "16": "Tripura",
+        "17": "Meghalaya",
+        "18": "Assam",
+        "19": "West Bengal",
+        "20": "Jharkhand",
+        "21": "Orissa",
+        "22": "Chattisgarh",
+        "23": "Madhya Pradesh",
+        "24": "Gujarat",
+        "25": "Daman and Diu",
+        "26": "Dadar and Nagar Haveli",
+        "27": "Maharashtra",
+        "28": "Andhra Pradesh",
+        "29": "Karnataka",
+        "30": "Goa",
+        "31": "Lakshadweep",
+        "32": "Kerala",
+        "33": "Tamil Nadu",
+        "34": "Puducherry",
+        "35": "Anadaman and Nicobar Islands",
+    }
+    number = compact(number)
+    pan_info = pan.info(number[2:12])
+    state_ut = STATE_UT_CODES.get(number[:2])
+    reg_count = gstin_ca.to_int(number[12])
+    return {
+        "state_or_ut": state_ut,
+        "pan_type": pan_info["card_holder_type"],
+        "initial": pan_info["initial"],
+        "registration_count": reg_count,
+    }

--- a/stdnum/in_/gstin.py
+++ b/stdnum/in_/gstin.py
@@ -64,18 +64,19 @@ InvalidChecksum: ...
 import re
 import stdnum.exceptions as e
 
-from stdnum.in_ import pan, gstin_ca
+from stdnum.in_ import gstin_ca
+from stdnum.in_ import pan
 from stdnum.util import clean
 
 
-def compact(number: str) -> str:
+def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
     return clean(number, " -").upper().strip()
 
 
-def validate(number: str) -> str:
+def validate(number):
     """Check if the number provided is a valid GSTIN. This checks the length,
     formatting, embedded PAN and check digit."""
 
@@ -92,7 +93,7 @@ def validate(number: str) -> str:
     return number
 
 
-def is_valid(number: str) -> bool:
+def is_valid(number):
     """Check if the number provided is a valid GSTIN. This checks the length,
     formatting, embedded PAN and check digit."""
 
@@ -102,7 +103,7 @@ def is_valid(number: str) -> bool:
         return False
 
 
-def info(number: str) -> dict[str, str, str, int]:
+def info(number):
     """Provide information that can be decoded locally from GSTIN (without
     API).
 

--- a/stdnum/in_/gstin_ca.py
+++ b/stdnum/in_/gstin_ca.py
@@ -1,0 +1,144 @@
+# gstin_ca.py - functions for performing GSTIN checksum algorithm
+#
+# Copyright (C) 2021 Gaurav Chauhan
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Goods and Services Tax identification number (GSTIN) Checksum Algorithm.
+
+The GSTIN Checksum algorithm is a custom checksum algorithm designed by Goods
+and Services Tax Network (GSTN) to catch errors in the identifier. 
+
+The alphanumeric characters in the identifier are converted to int as per a
+conversion table (provided below), then a series of arithmetic operations are
+performed to calculate the check digit. The check digit is then converted
+back to an alphanumeric character following the same table.
+
+Conversion Table: ["0": 0 ... "9": 9, "A": 10 ... "Z": 35]
+
+A major flaw in this algorithm is interchanging characters present at odd or
+even indices does not change the check digit.
+
+More information: 
+
+* https://medium.com/@dhananjaygokhale/decoding-gst-number-checksum-digit-1ef2c8c53ad6
+
+>>> checksum('27AAPFU0939F1Z')
+'27AAPFU0939F1ZV'
+>>> calc_check_digit('27AAPFU0939F1Z')
+'V'
+>>> validate('27AAPFU0939F1ZV')
+'27AAPFU0939F1ZV'
+>>> validate('27A@PF$0939F!ZV')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+>>> validate('27AAPFU0939F1ZO')
+Traceback (most recent call last):
+    ...
+InvalidChecksum: ...
+"""
+
+import stdnum.exceptions as e
+
+from stdnum.util import clean
+
+
+def compact(number: str) -> str:
+    """Convert the number to the minimal representation. This strips the
+    number of any valid separators and removes surrounding whitespace."""
+
+    return clean(number, " -").upper().strip()
+
+
+# Not using a dict as conversion table, the code was looking very inelegant.
+# Instead wrote two functions to handle the conversion.
+
+
+def to_int(char: str) -> int:
+    """Convert character to integer as per the conversion table. Takes an
+    alphanumeric str of length = 1"""
+
+    # Digits are returned as int. Unicode code point (UCP) [int] of uppercase
+    # letters are returned after subtracting 55 from them. Why 55? UCP of "A"
+    # is 65. 65 - 55 = 10. See the Conversion Table above.
+
+    if len(char) > 1:
+        raise e.InvalidLength()
+    if char.isalnum() is False:
+        raise e.InvalidComponent()
+    if char.isalpha() is True and char.isupper() is True:
+        return ord(char) - 55
+    return int(char)
+
+
+def to_char(index: int) -> str:
+    """Convert integer to character as per the conversion table. Takes an int
+    between 0 and 35, inclusive."""
+
+    # Integers [0,9] are returned as str. 55 is added to integers [10, 35]
+    # and returned after converting them to Unicode string.
+
+    if 0 <= index <= 9:
+        return str(index)
+    elif 10 <= index <= 35:
+        return chr(index + 55)
+    raise e.InvalidComponent()
+
+
+def checksum(number: str) -> str:
+    """Calculate checksum of an alphanumeric str. Returns the str with check
+    digit attached to it at the end."""
+
+    number = compact(number)
+    if number.isalnum() is True:
+        c = 0
+        for i in range(len(number)):
+            val = to_int(number[i])
+            if i % 2 == 0:
+                c += (val // 36) + (val % 36)
+            else:
+                val *= 2
+                c += (val // 36) + (val % 36)
+        check_digit_int = 36 - (c % 36)
+        return number + to_char(check_digit_int)
+    raise e.InvalidFormat()
+
+
+def calc_check_digit(number: str) -> str:
+    """Calculate check digit of an alphanumeric str."""
+
+    return checksum(number)[-1]
+
+
+def validate(number: str) -> str:
+    """Check if the number provided passes the checksum."""
+
+    number = compact(number)
+    if number.isalnum() is False:
+        raise e.InvalidFormat()
+    if checksum(number[:-1]) != number:
+        raise e.InvalidChecksum()
+    return number
+
+
+def is_valid(number: str) -> bool:
+    """Check if the number provided passes the checksum."""
+
+    try:
+        return bool(validate(number))
+    except e.ValidationError:
+        return False

--- a/stdnum/in_/gstin_ca.py
+++ b/stdnum/in_/gstin_ca.py
@@ -57,7 +57,7 @@ import stdnum.exceptions as e
 from stdnum.util import clean
 
 
-def compact(number: str) -> str:
+def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
@@ -99,7 +99,7 @@ def to_char(index: int) -> str:
     raise e.InvalidComponent()
 
 
-def checksum(number: str) -> str:
+def checksum(number):
     """Calculate checksum of an alphanumeric str. Returns the str with check
     digit attached to it at the end."""
 
@@ -118,13 +118,13 @@ def checksum(number: str) -> str:
     raise e.InvalidFormat()
 
 
-def calc_check_digit(number: str) -> str:
+def calc_check_digit(number):
     """Calculate check digit of an alphanumeric str."""
 
     return checksum(number)[-1]
 
 
-def validate(number: str) -> str:
+def validate(number):
     """Check if the number provided passes the checksum."""
 
     number = compact(number)
@@ -135,7 +135,7 @@ def validate(number: str) -> str:
     return number
 
 
-def is_valid(number: str) -> bool:
+def is_valid(number):
     """Check if the number provided passes the checksum."""
 
     try:

--- a/stdnum/in_/pan.py
+++ b/stdnum/in_/pan.py
@@ -23,13 +23,17 @@
 The Permanent Account Number (PAN) is a 10 digit alphanumeric identifier for
 Indian individuals, families and corporates for income tax purposes.
 
-The number is built up of 5 characters, 4 numbers and 1 character. The fourth
-character indicates the type of holder of the number and the last character
-is computed by an undocumented checksum algorithm.
+PAN is made up of 5 letter, 4 digits and one alphabetic check digit. The
+fourth character indicates the type of holder, the fifth character (of PAN)
+is either first character of the holder's name or first character of surname
+in case of "personal" PAN, next four digits are serial numbers running from
+0001 to 9999 and the last character is a check digit computed by an
+undocumented checksum algorithm.
 
 More information:
 
 * https://en.wikipedia.org/wiki/Permanent_account_number
+* https://incometaxindia.gov.in/tutorials/1.permanent%20account%20number%20(pan).pdf
 
 >>> validate('ACUPA7085R')
 'ACUPA7085R'
@@ -57,7 +61,7 @@ import stdnum.exceptions as e
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
@@ -65,7 +69,14 @@ def compact(number):
 
 
 def info(number: str) -> dict[str, str]:
-    """Provide information that can be decoded from the PAN."""
+    """Provide information that can be decoded from the PAN.
+
+    More information of the PAN holder can be viewed on the GST website if
+    they are registered under GST Act. Search by:
+
+    * PAN: https://services.gst.gov.in/services/searchtpbypan
+    * GSTIN: https://services.gst.gov.in/services/searchtp
+    """
 
     CARD_HOLDER_TYPES = {
         "A": "Association of Persons (AOP)",
@@ -107,8 +118,8 @@ def validate(number: str) -> str:
 
 
 def is_valid(number: str) -> bool:
-    """Check if the number provided is a valid PAN. This checks the
-    length and formatting."""
+    """Check if the number provided is a valid PAN. This checks the length
+    and formatting."""
 
     try:
         return bool(validate(number))
@@ -117,7 +128,8 @@ def is_valid(number: str) -> bool:
 
 
 def mask(number: str) -> str:
-    """Mask the PAN as per CBDT masking standard."""
+    """Mask the PAN as per Central Board of Direct Taxes (CBDT) masking
+    standard."""
 
     number = compact(number)
     return number[:5] + "XXXX" + number[-1:]

--- a/stdnum/in_/pan.py
+++ b/stdnum/in_/pan.py
@@ -61,14 +61,14 @@ import stdnum.exceptions as e
 from stdnum.util import clean
 
 
-def compact(number: str) -> str:
+def compact(number):
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
 
     return clean(number, " -").upper().strip()
 
 
-def info(number: str) -> dict[str, str]:
+def info(number):
     """Provide information that can be decoded from the PAN.
 
     More information of the PAN holder can be viewed on the GST website if
@@ -100,7 +100,7 @@ def info(number: str) -> dict[str, str]:
     }
 
 
-def validate(number: str) -> str:
+def validate(number):
     """Check if the number provided is a valid PAN. This checks the
     length and formatting."""
 
@@ -116,7 +116,7 @@ def validate(number: str) -> str:
     return number
 
 
-def is_valid(number: str) -> bool:
+def is_valid(number):
     """Check if the number provided is a valid PAN. This checks the length
     and formatting."""
 
@@ -126,7 +126,7 @@ def is_valid(number: str) -> bool:
         return False
 
 
-def mask(number: str) -> str:
+def mask(number):
     """Mask the PAN as per Central Board of Direct Taxes (CBDT) masking
     standard."""
 

--- a/stdnum/in_/pan.py
+++ b/stdnum/in_/pan.py
@@ -82,14 +82,13 @@ def info(number: str) -> dict[str, str]:
         "A": "Association of Persons (AOP)",
         "B": "Body of Individuals (BOI)",
         "C": "Company",
-        "F": "Firm",
-        "G": "Government",
-        "H": "HUF (Hindu Undivided Family)",
+        "F": "Firm/Limited Liability Partnership",
+        "G": "Government Agency",
+        "H": "Hindu Undivided Family (HUF)",
         "L": "Local Authority",
         "J": "Artificial Juridical Person",
         "P": "Individual",
-        "T": "Trust (AOP)",
-        "K": "Krish (Trust Krish)",
+        "T": "Trust",
     }
     number = compact(number)
     card_holder_type = CARD_HOLDER_TYPES.get(number[3])


### PR DESCRIPTION
I've added two new modules and updated two existing ones for handling Indian standard numbers. Following are the details: 

- Add:
  - [epic.py] Added a module to handle EPIC number (Indian Voter ID number).
  - [gstin.py & gstin_ca.py] Added modules to handle GSTIN (Indian VAT number). Only gstin.py is required to handle the numbers; gstin_ca.py is a helper module for implementing a custom checksum algorithm designed/utilized by GSTN.

- Update:
  - [aadhaar.py] Updated the module for handling Aadhaar. Refactored the codebase, improved docstrings and validate() functions now throws a ValidationError if the number entered is a palindrome (see documentation inside the module).
  - [pan.py] Updated the module for handling PAN. Refactored the codebase, improved docstrings and updated the data in CARD_HOLDER_TYPES, required by info() function, as per the Finance Act, 2021.