### PR TITLE
Fix SIRET validation for SIRET codes

### DIFF
--- a/stdnum/fr/siret.py
+++ b/stdnum/fr/siret.py
@@ -62,7 +62,14 @@ def validate(number):
         raise InvalidFormat()
     if len(number) != 14:
         raise InvalidLength()
-    luhn.validate(number)
+    try:
+        luhn.validate(number)
+    except InvalidChecksum:
+        sum_of_digits = 0
+        for digit in str(number):
+            sum_of_digits += int(digit)
+        if(sum_of_digits % 5)
+            raise InvalidChecksum()
     siren.validate(number[:9])
     return number
 

--- a/stdnum/fr/siret.py
+++ b/stdnum/fr/siret.py
@@ -26,6 +26,8 @@ and facilities. The Luhn checksum is used to validate the numbers.
 
 >>> validate('73282932000074')
 '73282932000074'
+>>> validate('35600000009075')
+'35600000009075'
 >>> validate('73282932000079')
 Traceback (most recent call last):
     ...

--- a/stdnum/fr/siret.py
+++ b/stdnum/fr/siret.py
@@ -68,7 +68,7 @@ def validate(number):
         sum_of_digits = 0
         for digit in str(number):
             sum_of_digits += int(digit)
-        if(sum_of_digits % 5)
+        if sum_of_digits % 5:
             raise InvalidChecksum()
     siren.validate(number[:9])
     return number


### PR DESCRIPTION
Some SIRET codes do not validate Luhn algorithm but are valid.
In those cases, sum of the digits should be a multiple of 5.