### PR TITLE
Update handelsregisternummer.py

### DIFF
--- a/stdnum/de/handelsregisternummer.py
+++ b/stdnum/de/handelsregisternummer.py
@@ -229,6 +229,7 @@ _courts.update(
         ('Bad Homburg', 'Bad Homburg v.d.H.'),
         ('Berlin', 'Berlin (Charlottenburg)'),
         ('Charlottenburg', 'Berlin (Charlottenburg)'),
+        ('Charlottenburg (Berlin)', 'Berlin (Charlottenburg)'),
         ('Kaln', 'Köln'),  # for encoding issues
         ('Kempten', 'Kempten (Allgäu)'),
         ('Ludwigshafen am Rhein (Ludwigshafen)', 'Ludwigshafen a.Rhein (Ludwigshafen)'),


### PR DESCRIPTION
Charlottenburg (Berlin) is a valid court representation for Berlin (Charlottenburg) ([example](https://www.northdata.com/VRB+Service+GmbH,+Berlin/Amtsgericht+Charlottenburg+%28Berlin%29+HRB+103587+B))