### PR TITLE
Alter vat alias for India

### DIFF
--- a/stdnum/in_/__init__.py
+++ b/stdnum/in_/__init__.py
@@ -21,4 +21,4 @@
 """Collection of Indian numbers."""
 
 # provide aliases
-from stdnum.in_ import gstin as vat  # noqa: F401
+from stdnum.in_ import pan as vat  # noqa: F401


### PR DESCRIPTION
According to https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/India-TIN.pdf the "Permanent Account Number" is the TIN number.