### PR TITLE
Add vat alias so stdnum.vatin works for the United States

### DIFF
--- a/stdnum/us/__init__.py
+++ b/stdnum/us/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of United States numbers."""
+
+# provide aliases
+from stdnum.us import ein as vat  # noqa: F401


### PR DESCRIPTION
While stdnum provides several modules implementing some sort of TIN for the United States, EIN is the only only used for companies and institutions.