### PR TITLE
python-version should be a string, not a float

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', pypy2.7, pypy3.6]
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.6']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: '3.x'
       - name: Install dependencies
         run: python -m pip install --upgrade pip tox
       - name: Run tox ${{ matrix.tox_job }}


### PR DESCRIPTION
This shows clearly with `'3.10'` which is different from `'3.1'`.