### PR TITLE
 Fix CI issues after flake8 update 5 → 6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,14 +27,22 @@ all_files  = 1
 
 [flake8]
 ignore =
-  D205,D209,D400  # our docstrings are multi-line blobs
-  D302  # We don't care about Unicode docstrings
-  E731  # we occasionally use lambda
-  F403,F405  # we use * imports
-  Q001  # we use '''...''' multi-line strings
-  Q003  # don't force "" strings to avoid escaping quotes
-  T001,T201  # we use print statements in the update scripts
-  W504  # we put the binary operator on the preceding line
+  # our docstrings are multi-line blobs
+  D205,D209,D400,
+  # We don't care about Unicode docstrings
+  D302,
+  # we occasionally use lambda
+  E731,
+  # we use * imports
+  F403,F405,
+  # we use '''...''' multi-line strings
+  Q001,
+  # don't force "" strings to avoid escaping quotes
+  Q003,
+  # we use print statements in the update scripts
+  T001,T201,
+  # we put the binary operator on the preceding line
+  W504,
 max-complexity = 15
 max-line-length = 120
 extend-exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv=
 
 [testenv:flake8]
 skip_install = true
-deps = flake8<6.0
+deps = flake8
        flake8-author
        flake8-blind-except
        flake8-bugbear
@@ -24,7 +24,7 @@ deps = flake8<6.0
        flake8-exact-pin
        flake8-isort
        flake8-print
-       flake8-quotes
+       flake8-quotes>=3.3.2  # for compatibility with flake8 6.0
        flake8-tidy-imports
        flake8-tuple
        pep8-naming


### PR DESCRIPTION
https://github.com/PyCQA/flake8/issues/1760

* Fix incorrect `setup.cfg` syntax.
* Plugin flake8-quotes is currently incompatible with flake8 v6. Work around by pinning flake8 until https://github.com/zheller/flake8-quotes/pull/111 is merged.

Fixes #342.