### PR TITLE
Add support for Finland HETU new century indicating signs

### DIFF
--- a/stdnum/fi/hetu.py
+++ b/stdnum/fi/hetu.py
@@ -50,15 +50,15 @@ from stdnum.util import clean
 
 _century_codes = {
     '+': 1800,
-    '-': 1900,
-    'A': 2000,
 }
+_century_codes.update(dict.fromkeys(('-', 'Y', 'X', 'W', 'V', 'U'), 1900))
+_century_codes.update(dict.fromkeys(('A', 'B', 'C', 'D', 'E', 'F'), 2000))
 
 # Finnish personal identity codes are composed of date part, century
 # indicating sign, individual number and control character.
 # ddmmyyciiiC
 _hetu_re = re.compile(r'^(?P<day>[0123]\d)(?P<month>[01]\d)(?P<year>\d\d)'
-                      r'(?P<century>[-+A])(?P<individual>\d\d\d)'
+                      r'(?P<century>[-+ABCDEFYXWVU])(?P<individual>\d\d\d)'
                       r'(?P<control>[0-9ABCDEFHJKLMNPRSTUVWXY])$')
 
 

--- a/tests/test_fi_hetu.doctest
+++ b/tests/test_fi_hetu.doctest
@@ -39,6 +39,14 @@ Normal values that should just work.
 >>> hetu.validate('131052a308t')
 '131052A308T'
 
+From the beginning of year 2023, additional century indicating signs were added.
+This doesn't affect the checksum calculation.
+
+>>> hetu.validate('131052B308T')
+'131052B308T'
+
+>>> hetu.validate('131052X308T')
+'131052X308T'
 
 Invalid checksum:
 


### PR DESCRIPTION
Finland's HETU updated on 2023-01-01 adding more century indicating sign options. Detailed information of the reformation can be found at the [Digital and Population Data Services Agency site](https://dvv.fi/en/reform-of-personal-identity-code).

The reformation doesn't affect checksum validation, and all the old HETU's are still valid.