### PR TITLE
Add 2020 decade Albania TIN

### DIFF
--- a/stdnum/al/nipt.py
+++ b/stdnum/al/nipt.py
@@ -46,7 +46,7 @@ from stdnum.util import clean
 
 
 # regular expression for matching number
-_nipt_re = re.compile(r'^[JKL][0-9]{8}[A-Z]$')
+_nipt_re = re.compile(r'^[JKLM][0-9]{8}[A-Z]$')
 
 
 def compact(number):


### PR DESCRIPTION
The first letter of Albania TIN corresponds to the decade it was issued. (Source: https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/Albania-TIN.pdf)

This commit adds 'M' to the regex in order to match TIN from this decade.