### PR TITLE
Minor ISSN and ISBN documentation fixes.

### DIFF
--- a/stdnum/isbn.py
+++ b/stdnum/isbn.py
@@ -81,7 +81,7 @@ def compact(number, convert=False):
 
 def _calc_isbn10_check_digit(number):
     """Calculate the ISBN check digit for 10-digit numbers. The number passed
-    should not have the check bit included."""
+    should not have the check digit included."""
     check = sum((i + 1) * int(n)
                 for i, n in enumerate(number)) % 11
     return 'X' if check == 10 else str(check)
@@ -89,7 +89,7 @@ def _calc_isbn10_check_digit(number):
 
 def validate(number, convert=False):
     """Check if the number provided is a valid ISBN (either a legacy 10-digit
-    one or a 13-digit one). This checks the length and the check bit but does
+    one or a 13-digit one). This checks the length and the check digit but does
     not check if the group and publisher are valid (use split() for that)."""
     number = compact(number, convert=False)
     if not isdigits(number[:-1]):
@@ -123,7 +123,7 @@ def isbn_type(number):
 
 def is_valid(number):
     """Check if the number provided is a valid ISBN (either a legacy 10-digit
-    one or a 13-digit one). This checks the length and the check bit but does
+    one or a 13-digit one). This checks the length and the check digit but does
     not check if the group and publisher are valid (use split() for that)."""
     try:
         return bool(validate(number))
@@ -174,7 +174,7 @@ def to_isbn10(number):
 
 def split(number, convert=False):
     """Split the specified ISBN into an EAN.UCC prefix, a group prefix, a
-    registrant, an item number and a check-digit. If the number is in ISBN-10
+    registrant, an item number and a check digit. If the number is in ISBN-10
     format the returned EAN.UCC prefix is '978'. If the convert parameter is
     True the number is converted to ISBN-13 format first."""
     # clean up number
@@ -198,7 +198,7 @@ def split(number, convert=False):
 def format(number, separator='-', convert=False):
     """Reformat the number to the standard presentation format with the
     EAN.UCC prefix (if any), the group prefix, the registrant, the item
-    number and the check-digit separated (if possible) by the specified
+    number and the check digit separated (if possible) by the specified
     separator. Passing an empty separator should equal compact() though this
     is less efficient. If the convert parameter is True the number is
     converted to ISBN-13 format first."""

--- a/stdnum/issn.py
+++ b/stdnum/issn.py
@@ -61,8 +61,8 @@ def compact(number):
 
 
 def calc_check_digit(number):
-    """Calculate the ISSN check digit for 10-digit numbers. The number passed
-    should not have the check bit included."""
+    """Calculate the ISSN check digit for 8-digit numbers. The number passed
+    should not have the check digit included."""
     check = (11 - sum((8 - i) * int(n)
                       for i, n in enumerate(number))) % 11
     return 'X' if check == 10 else str(check)


### PR DESCRIPTION
This PR only changes comments / documentation for clarity. No code is changed.

* Fix potentially confusing method description -- ISSN has 8 digits not 10.
* Refer to check digits as 'digits' not 'bits'.
* Consistent use of `check digit` rather than `check-digit` in isbn.py

I know this is a minor and pedantic change, but the 10 digit ISSN comment threw me and I had to confirm the code was doing the right thing (it is!). Fixing to prevent it confusing anyone else.