### PR TITLE
Update rnc.py

### DIFF
--- a/stdnum/do/rnc.py
+++ b/stdnum/do/rnc.py
@@ -54,7 +54,7 @@ whitelist = set('''
 '''.split())
 
 
-dgii_wsdl = 'https://www.dgii.gov.do/wsMovilDGII/WSMovilDGII.asmx?WSDL'
+dgii_wsdl = 'https://www.dgii.gov.do/ventanillaunica/ventanillaunica.asmx?WSDL'
 """The WSDL URL of DGII validation service."""
 
 


### PR DESCRIPTION
The dgii_wsdl URL changed from https://www.dgii.gov.do/wsMovilDGII/WSMovilDGII.asmx?WSDL to https://www.dgii.gov.do/ventanillaunica/ventanillaunica.asmx?WSDL.