### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox_job: [docs, flake8, headers]
+        tox_job: [docs, flake8, mypy, headers]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ __pycache__
 
 # /
 /.coverage
+/.mypy_cache
+/.ruff_cache
 /.tox
+/.venv
 /build
 /coverage
 /dist

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.9
+strict = True
+warn_unreachable = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,14 @@ owner=root
 group=root
 
 [tool:pytest]
-addopts = --doctest-modules --doctest-glob="*.doctest" stdnum tests --ignore=stdnum/iso9362.py --cov=stdnum --cov-report=term-missing:skip-covered --cov-report=html
+addopts = --doctest-modules --doctest-glob="*.doctest" stdnum tests --ignore=stdnum/iso9362.py --ignore=stdnum/_types.py --cov=stdnum --cov-report=term-missing:skip-covered --cov-report=html
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 
 [coverage:run]
 branch = true
+omit =
+  _types.py
+  _typing.py
 
 [coverage:report]
 fail_under=100
@@ -32,16 +35,26 @@ ignore =
   Q003  # don't force "" strings to avoid escaping quotes
   T001,T201  # we use print statements in the update scripts
   W504  # we put the binary operator on the preceding line
+per-file-ignores =
+  # typing re-exports
+  stdnum/_typing.py: F401,I250
 max-complexity = 15
 max-line-length = 120
 extend-exclude =
   .github
+  .mypy_cache
   .pytest_cache
+  .ruff_cache
+  .venv
   build
 
 [isort]
 lines_after_imports = 2
 multi_line_output = 4
+extra_standard_library =
+  typing_extensions
+classes =
+  IO
 known_third_party =
   lxml
   openpyxl

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -77,8 +76,11 @@ setup(
         'Topic :: Text Processing :: General',
     ],
     packages=find_packages(),
-    install_requires=[],
-    package_data={'': ['*.dat', '*.crt']},
+    python_requires='>=3.7',
+    install_requires=[
+        'importlib_resources >= 1.3  ; python_version < "3.9"',
+    ],
+    package_data={'': ['*.dat', '*.crt', 'py.typed']},
     extras_require={
         # The SOAP feature is only required for a number of online tests
         # of numbers such as the EU VAT VIES lookup, the Dominican Republic

--- a/stdnum/__init__.py
+++ b/stdnum/__init__.py
@@ -36,6 +36,7 @@ InvalidChecksum: ...
 Apart from the validate() function, many modules provide extra
 parsing, validation, formatting or conversion functions.
 """
+from __future__ import annotations
 
 from stdnum.util import get_cc_module
 

--- a/stdnum/_types.py
+++ b/stdnum/_types.py
@@ -1,0 +1,77 @@
+# _types.py - module for defining custom types
+#
+# Copyright (C) 2025 David Salvisberg
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Module containing custom types.
+
+This module is designed to be accessed through `stdnum._typing` so
+you only have the overhead and runtime requirement of Python 3.9
+and `typing_extensions`, when that type is introspected at runtime.
+
+As such this module should never be accessed directly.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+from typing_extensions import Required, TypedDict
+
+
+class NumberValidationModule(Protocol):
+    """Minimal interface for a number validation module."""
+
+    def compact(self, number: str) -> str:
+        """Convert the number to the minimal representation."""
+
+    def validate(self, number: str) -> str:
+        """Check if the number provided is a valid number of its type."""
+
+    def is_valid(self, number: str) -> bool:
+        """Check if the number provided is a valid number of its type."""
+
+
+class IMSIInfo(TypedDict, total=False):
+    """Info `dict` returned by `stdnum.imsi.info`."""
+
+    number: Required[str]
+    mcc: Required[str]
+    mnc: Required[str]
+    msin: Required[str]
+    country: str
+    cc: str
+    brand: str
+    operator: str
+    status: str
+    bands: str
+
+
+class GSTINInfo(TypedDict):
+    """Info `dict` returned by `stdnum.in_.gstin.info`."""
+
+    state: str | None
+    pan: str
+    holder_type: str
+    initial: str
+    registration_count: int
+
+
+class PANInfo(TypedDict):
+    """Info `dict` returned by `stdnum.in_.pan.info`."""
+
+    holder_type: str
+    initial: str

--- a/stdnum/_typing.py
+++ b/stdnum/_typing.py
@@ -1,0 +1,119 @@
+# _typing.py - module for typing shims with reduced runtime overhead
+#
+# Copyright (C) 2025 David Salvisberg
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Compatibility shims for the Python typing module.
+
+This module is designed in a way, such, that runtime use of
+annotations is possible starting with Python 3.9, but it still
+supports Python 3.6 - 3.8 if the package is used normally without
+introspecting the annotations of the API.
+
+You should never import *from* this module, you should always import
+the entire module and then access the members via attribute access.
+
+I.e. use the module like this:
+```python
+from stdnum import _typing as t
+
+foo: t.Any = ...
+```
+
+Instead of like this:
+```python
+from stdnum._typing import Any
+
+foo: Any = ...
+```
+
+The exception to that rule are `TYPE_CHECKING` `cast` and `deprecated`
+which can be used at runtime.
+"""
+
+from __future__ import annotations
+
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator as Generator
+    from collections.abc import Iterable as Iterable
+    from collections.abc import Mapping as Mapping
+    from collections.abc import Sequence as Sequence
+    from typing import Any as Any
+    from typing import IO as IO
+    from typing import Literal as Literal
+    from typing import cast as cast
+    from typing_extensions import TypeAlias as TypeAlias
+    from typing_extensions import deprecated as deprecated
+
+    from stdnum._types import GSTINInfo as GSTINInfo
+    from stdnum._types import IMSIInfo as IMSIInfo
+    from stdnum._types import NumberValidationModule as NumberValidationModule
+    from stdnum._types import PANInfo as PANInfo
+else:
+    def cast(typ, val):
+        """Cast a value to a type."""
+        return val
+
+    class deprecated:  # noqa: N801
+        """Simplified backport of `warnings.deprecated`.
+
+        This backport doesn't handle classes or async functions.
+        """
+
+        def __init__(self, message, category=DeprecationWarning, stacklevel=1):  # noqa: D107
+            self.message = message
+            self.category = category
+            self.stacklevel = stacklevel
+
+        def __call__(self, func):  # noqa: D102
+            func.__deprecated__ = self.message
+
+            if self.category is None:
+                return func
+
+            import functools
+            import warnings
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                warnings.warn(self.message, category=self.category, stacklevel=self.stacklevel + 1)
+                return func(*args, **kwargs)
+
+            wrapper.__deprecated__ = self.message
+            return wrapper
+
+    def __getattr__(name):
+        if name in {'Generator', 'Iterable', 'Mapping', 'Sequence'}:
+            import collections.abc
+            return getattr(collections.abc, name)
+        elif name in {'Any', 'IO', 'Literal'}:
+            import typing
+            return getattr(typing, name)
+        elif name == 'TypeAlias':
+            import sys
+            if sys.version_info >= (3, 10):
+                import typing
+            else:
+                import typing_extensions as typing
+            return getattr(typing, name)
+        elif name in {'GSTINInfo', 'IMSIInfo', 'NumberValidationModule', 'PANInfo'}:
+            import stdnum._types
+            return getattr(stdnum._types, name)
+        else:
+            raise AttributeError(name)

--- a/stdnum/ad/__init__.py
+++ b/stdnum/ad/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Andorran numbers."""
+from __future__ import annotations
 
 # Provide aliases.
 from stdnum.ad import nrt as vat  # noqa: F401

--- a/stdnum/ad/nrt.py
+++ b/stdnum/ad/nrt.py
@@ -43,12 +43,13 @@ InvalidComponent: ...
 >>> format('D059888N')
 'D-059888-N'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -57,7 +58,7 @@ def compact(number):
     return clean(number, ' -.').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Andorra NRT number.
 
     This checks the length, formatting and other constraints. It does not check
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Andorra NRT number."""
     try:
         return bool(validate(number))
@@ -87,7 +88,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[0], number[1:-1], number[-1]])

--- a/stdnum/al/__init__.py
+++ b/stdnum/al/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Albanian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.al import nipt as vat  # noqa: F401

--- a/stdnum/al/nipt.py
+++ b/stdnum/al/nipt.py
@@ -49,6 +49,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -60,7 +61,7 @@ from stdnum.util import clean
 _nipt_re = re.compile(r'^[A-M][0-9]{8}[A-Z]$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -71,7 +72,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length and
     formatting."""
     number = compact(number)
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ar/__init__.py
+++ b/stdnum/ar/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Argentinian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.ar import cuit as vat  # noqa: F401

--- a/stdnum/ar/cbu.py
+++ b/stdnum/ar/cbu.py
@@ -38,18 +38,19 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (3, 1, 7, 9)
     check = sum(int(n) * weights[i % 4]
@@ -57,7 +58,7 @@ def calc_check_digit(number):
     return str((10 - check) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CBU."""
     number = compact(number)
     if len(number) != 22:
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CBU."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:8], number[8:]))

--- a/stdnum/ar/cuit.py
+++ b/stdnum/ar/cuit.py
@@ -40,18 +40,19 @@ InvalidChecksum: ...
 >>> format('20267565393')
 '20-26756539-3'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
     check = sum(w * int(n) for w, n in zip(weights, number)) % 11
@@ -66,7 +67,7 @@ _cuit_tpes = (
 )
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CUIT."""
     number = compact(number)
     if len(number) != 11:
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CUIT."""
     try:
         return bool(validate(number))
@@ -88,7 +89,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return (number[0:2] + '-' + number[2:10] + '-' + number[10:])

--- a/stdnum/ar/dni.py
+++ b/stdnum/ar/dni.py
@@ -37,18 +37,19 @@ InvalidLength: ...
 >>> format('20123456')
 '20.123.456'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid DNI."""
     number = compact(number)
     if not isdigits(number):
@@ -58,7 +59,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid DNI."""
     try:
         return bool(validate(number))
@@ -66,7 +67,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '.'.join((number[:-6], number[-6:-3], number[-3:]))

--- a/stdnum/at/__init__.py
+++ b/stdnum/at/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Austrian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.at import postleitzahl as postal_code  # noqa: F401

--- a/stdnum/at/businessid.py
+++ b/stdnum/at/businessid.py
@@ -37,6 +37,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -47,7 +48,7 @@ from stdnum.util import clean
 _businessid_re = re.compile('^[0-9]+[a-z]$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace.
     Preceding "FN" is also removed."""
@@ -57,7 +58,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid company register number. This only
     checks the formatting."""
     number = compact(number)
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid company register number."""
     try:
         return bool(validate(number))

--- a/stdnum/at/postleitzahl.py
+++ b/stdnum/at/postleitzahl.py
@@ -44,18 +44,19 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number).strip()
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Return a dictionary of data about the supplied number. This typically
     returns the location."""
     number = compact(number)
@@ -63,7 +64,7 @@ def info(number):
     return numdb.get('at/postleitzahl').info(number)[0][1]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid postal code."""
     number = compact(number)
     if not isdigits(number):
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid postal code."""
     try:
         return bool(validate(number))

--- a/stdnum/at/tin.py
+++ b/stdnum/at/tin.py
@@ -43,18 +43,19 @@ More information:
 >>> format('591199013')
 '59-119/9013'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -./,').strip()
 
 
-def _min_fa(office):
+def _min_fa(office: str) -> str:
     """Convert the tax office name to something that we can use for
     comparison without running into encoding issues."""
     return ''.join(
@@ -62,7 +63,7 @@ def _min_fa(office):
         if x in 'bcdefghijklmnopqrstvwxyz')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     number = compact(number)
     s = sum(
@@ -71,7 +72,7 @@ def calc_check_digit(number):
     return str((10 - s) % 10)
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Return a dictionary of data about the supplied number. This typically
     returns the the tax office and region."""
     number = compact(number)
@@ -79,7 +80,7 @@ def info(number):
     return numdb.get('at/fa').info(number[:2])[0][1]
 
 
-def validate(number, office=None):
+def validate(number: str, office: str | None = None) -> str:
     """Check if the number is a valid tax identification number. This checks
     the length and formatting. The tax office can be supplied to check that
     the number was issued in the specified tax office."""
@@ -93,12 +94,12 @@ def validate(number, office=None):
     i = info(number)
     if not i:
         raise InvalidComponent()
-    if office and _min_fa(i.get('office')) != _min_fa(office):
+    if office and _min_fa(i.get('office', '')) != _min_fa(office):
         raise InvalidComponent()
     return number
 
 
-def is_valid(number, office=None):
+def is_valid(number: str, office: str | None = None) -> bool:
     """Check if the number is a valid tax identification number. This checks
     the length, formatting and check digit."""
     try:
@@ -107,7 +108,7 @@ def is_valid(number, office=None):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '%s-%s/%s' % (number[:2], number[2:5], number[5:])

--- a/stdnum/at/uid.py
+++ b/stdnum/at/uid.py
@@ -31,13 +31,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -./').upper().strip()
@@ -46,13 +47,13 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     return str((6 - luhn.checksum(number[1:])) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/at/vnr.py
+++ b/stdnum/at/vnr.py
@@ -36,25 +36,26 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The fourth digit in the number is
     ignored."""
     weights = (3, 7, 9, 0, 5, 8, 4, 2, 1, 6)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -67,7 +68,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/au/__init__.py
+++ b/stdnum/au/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Australian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.au import abn as vat  # noqa: F401

--- a/stdnum/au/abn.py
+++ b/stdnum/au/abn.py
@@ -38,18 +38,19 @@ InvalidChecksum: ...
 >>> format('51824753556')
 '51 824 753 556'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits that should be prepended to make the number
     valid."""
     weights = (3, 5, 7, 9, 11, 13, 15, 17, 19)
@@ -57,7 +58,7 @@ def calc_check_digits(number):
     return str(11 + (s - 1) % 89)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ABN. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -70,7 +71,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ABN."""
     try:
         return bool(validate(number))
@@ -78,7 +79,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[0:2], number[2:5], number[5:8], number[8:]))

--- a/stdnum/au/acn.py
+++ b/stdnum/au/acn.py
@@ -40,23 +40,24 @@ InvalidChecksum: ...
 >>> to_abn('002 724 334')
 '43002724334'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the checksum."""
     return str((sum(int(n) * (i - 8) for i, n in enumerate(number))) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ACN. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -69,7 +70,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ACN."""
     try:
         return bool(validate(number))
@@ -77,13 +78,13 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[0:3], number[3:6], number[6:]))
 
 
-def to_abn(number):
+def to_abn(number: str) -> str:
     """Convert the number to an Australian Business Number (ABN)."""
     from stdnum.au import abn
     number = compact(number)

--- a/stdnum/au/tfn.py
+++ b/stdnum/au/tfn.py
@@ -41,24 +41,25 @@ InvalidChecksum: ...
 >>> format('123456782')
 '123 456 782'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (1, 4, 3, 7, 5, 8, 6, 9, 10)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid TFN. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid TFN."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[0:3], number[3:6], number[6:]))

--- a/stdnum/be/__init__.py
+++ b/stdnum/be/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Belgian numbers."""
+from __future__ import annotations
 
 # provide businessid as an alias
 from stdnum.be import nn as personalid  # noqa: F401

--- a/stdnum/be/bis.py
+++ b/stdnum/be/bis.py
@@ -64,19 +64,23 @@ datetime.date(1998, 7, 28)
 >>> get_gender('98.47.28-997.65')
 'M'
 """
+from __future__ import annotations
 
+import datetime
+
+from stdnum import _typing as t
 from stdnum.be import nn
 from stdnum.exceptions import *
 from stdnum.util import isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the number
     of any valid separators and removes surrounding whitespace."""
     return nn.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid BIS Number."""
     number = compact(number)
     if not isdigits(number) or int(number) <= 0:
@@ -89,7 +93,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid BIS Number."""
     try:
         return bool(validate(number))
@@ -97,29 +101,30 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return nn.format(number)
 
 
-def get_birth_year(number):
+def get_birth_year(number: str) -> int | None:
     """Return the year of the birth date."""
     return nn.get_birth_year(number)
 
 
-def get_birth_month(number):
+def get_birth_month(number: str) -> int | None:
     """Return the month of the birth date."""
     return nn.get_birth_month(number)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date | None:
     """Return the date of birth."""
     return nn.get_birth_date(number)
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F'] | None:
     """Get the person's gender ('M' or 'F'), which for BIS
     numbers is only known if the month was incremented with 40."""
     number = compact(number)
     if int(number[2:4]) >= 40:
         return nn.get_gender(number)
+    return None

--- a/stdnum/be/eid.py
+++ b/stdnum/be/eid.py
@@ -53,18 +53,19 @@ InvalidChecksum: ...
 >>> format('591191706458')
 '591-1917064-58'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -./').upper().strip()
 
 
-def _calc_check_digits(number):
+def _calc_check_digits(number: str) -> str:
     """Calculate the expected check digits for the number, calculated as
     the remainder of dividing the first 10 digits of the number by 97.
     If the remainder is 0, the check number is set to 97.
@@ -72,7 +73,7 @@ def _calc_check_digits(number):
     return '%02d' % ((int(number[:10]) % 97) or 97)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ID card number.
     This checks the length, formatting and check digit."""
     number = compact(number)
@@ -85,7 +86,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Belgian ID Card number."""
     try:
         return bool(validate(number))
@@ -93,7 +94,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[:3], number[3:10], number[10:]))

--- a/stdnum/be/iban.py
+++ b/stdnum/be/iban.py
@@ -46,6 +46,7 @@ InvalidComponent: ...
 >>> to_bic('BE83138811735115') is None
 True
 """
+from __future__ import annotations
 
 from stdnum import iban
 from stdnum.exceptions import *
@@ -58,13 +59,13 @@ compact = iban.compact
 format = iban.format
 
 
-def _calc_check_digits(number):
+def _calc_check_digits(number: str) -> str:
     """Calculate the check digits over the provided part of the number."""
     check = int(number) % 97
     return '%02d' % (check or 97)
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Return a dictionary of data about the supplied number. This typically
     returns the name of the bank and a BIC if it is valid."""
     number = compact(number)
@@ -72,14 +73,12 @@ def info(number):
     return numdb.get('be/banks').info(number[4:7])[0][1]
 
 
-def to_bic(number):
+def to_bic(number: str) -> str | None:
     """Return the BIC for the bank that this number refers to."""
-    bic = info(number).get('bic')
-    if bic:
-        return str(bic)
+    return info(number).get('bic')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Belgian IBAN."""
     number = iban.validate(number, check_country=False)
     if not number.startswith('BE'):
@@ -91,7 +90,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Belgian IBAN."""
     try:
         return bool(validate(number))

--- a/stdnum/be/nn.py
+++ b/stdnum/be/nn.py
@@ -81,22 +81,24 @@ datetime.date(1985, 7, 30)
 >>> get_gender('85.07.30-033 28')
 'M'
 """
+from __future__ import annotations
 
 import calendar
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the number
     of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').strip()
     return number
 
 
-def _checksum(number):
+def _checksum(number: str) -> int:
     """Calculate the checksum and return the detected century."""
     numbers = [number]
     if int(number[:2]) + 2000 <= datetime.date.today().year:
@@ -107,7 +109,7 @@ def _checksum(number):
     raise InvalidChecksum()
 
 
-def _get_birth_date_parts(number):
+def _get_birth_date_parts(number: str) -> tuple[int | None, int | None, int | None]:
     """Check if the number's encoded birth date is valid, and return the contained
     birth year, month and day of month, accounting for unknown values."""
     century = _checksum(number)
@@ -138,7 +140,7 @@ def _get_birth_date_parts(number):
     return (year, month, day)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid National Number."""
     number = compact(number)
     if not isdigits(number) or int(number) <= 0:
@@ -151,7 +153,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid National Number."""
     try:
         return bool(validate(number))
@@ -159,7 +161,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return (
@@ -167,26 +169,27 @@ def format(number):
         '-' + '.'.join([number[6:9], number[9:11]]))
 
 
-def get_birth_year(number):
+def get_birth_year(number: str) -> int | None:
     """Return the year of the birth date."""
     year, month, day = _get_birth_date_parts(compact(number))
     return year
 
 
-def get_birth_month(number):
+def get_birth_month(number: str) -> int | None:
     """Return the month of the birth date."""
     year, month, day = _get_birth_date_parts(compact(number))
     return month
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date | None:
     """Return the date of birth."""
     year, month, day = _get_birth_date_parts(compact(number))
-    if None not in (year, month, day):
+    if year is not None and month is not None and day is not None:
         return datetime.date(year, month, day)
+    return None
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's gender ('M' or 'F')."""
     number = compact(number)
     if int(number[6:9]) % 2:

--- a/stdnum/be/ssn.py
+++ b/stdnum/be/ssn.py
@@ -88,7 +88,11 @@ datetime.date(1998, 7, 28)
 'M'
 
 """
+from __future__ import annotations
 
+import datetime
+
+from stdnum import _typing as t
 from stdnum.be import bis, nn
 from stdnum.exceptions import *
 
@@ -96,13 +100,13 @@ from stdnum.exceptions import *
 _ssn_modules = (nn, bis)
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return nn.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Belgian SSN. This searches for
     the proper sub-type and validates using that."""
     try:
@@ -113,7 +117,7 @@ def validate(number):
         return nn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Belgian SSN number."""
     try:
         return bool(validate(number))
@@ -121,35 +125,37 @@ def is_valid(number):
         return False
 
 
-def guess_type(number):
+def guess_type(number: str) -> str | None:
     """Return the Belgian SSN type for which this number is valid."""
     for mod in _ssn_modules:
         if mod.is_valid(number):
             return mod.__name__.rsplit('.', 1)[-1]
+    return None
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return nn.format(number)
 
 
-def get_birth_year(number):
+def get_birth_year(number: str) -> int | None:
     """Return the year of the birth date."""
     return nn.get_birth_year(number)
 
 
-def get_birth_month(number):
+def get_birth_month(number: str) -> int | None:
     """Return the month of the birth date."""
     return nn.get_birth_month(number)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date | None:
     """Return the date of birth."""
     return nn.get_birth_date(number)
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F'] | None:
     """Get the person's gender ('M' or 'F')."""
     for mod in _ssn_modules:
         if mod.is_valid(number):
-            return mod.get_gender(number)
+            return mod.get_gender(number)  # type: ignore[no-any-return]
+    return None

--- a/stdnum/be/vat.py
+++ b/stdnum/be/vat.py
@@ -34,12 +34,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -./').upper().strip()
@@ -52,12 +53,12 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     return (int(number[:-2]) + int(number[-2:])) % 97
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -70,7 +71,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/bg/egn.py
+++ b/stdnum/bg/egn.py
@@ -40,6 +40,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import datetime
 
@@ -47,20 +48,20 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     weights = (2, 4, 8, 5, 10, 9, 7, 3, 6)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 11 % 10)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     year = int(number[0:2]) + 1900
@@ -78,7 +79,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid national identification number. This
     checks the length, formatting, embedded date and check digit."""
     number = compact(number)
@@ -95,7 +96,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid national identification number."""
     try:
         return bool(validate(number))

--- a/stdnum/bg/pnf.py
+++ b/stdnum/bg/pnf.py
@@ -34,25 +34,26 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     weights = (21, 19, 17, 13, 11, 9, 7, 3, 1)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid national identification number. This
     checks the length, formatting, embedded date and check digit."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid national identification number."""
     try:
         return bool(validate(number))

--- a/stdnum/bg/vat.py
+++ b/stdnum/bg/vat.py
@@ -33,13 +33,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.bg import egn, pnf
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -48,7 +49,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit_legal(number):
+def calc_check_digit_legal(number: str) -> str:
     """Calculate the check digit for legal entities. The number passed
     should not have the check digit included."""
     check = sum((i + 1) * int(n) for i, n in enumerate(number)) % 11
@@ -57,14 +58,14 @@ def calc_check_digit_legal(number):
     return str(check % 10)
 
 
-def calc_check_digit_other(number):
+def calc_check_digit_other(number: str) -> str:
     """Calculate the check digit for others. The number passed should not
     have the check digit included."""
     weights = (4, 3, 2, 7, 6, 5, 4, 3, 2)
     return str((11 - sum(w * int(n) for w, n in zip(weights, number))) % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -84,7 +85,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/bic.py
+++ b/stdnum/bic.py
@@ -46,6 +46,7 @@ InvalidFormat: ..
 'AGRIFRPP'
 
 """
+from __future__ import annotations
 
 import re
 
@@ -56,13 +57,13 @@ from stdnum.util import clean
 _bic_re = re.compile(r'^[A-Z]{6}[0-9A-Z]{2}([0-9A-Z]{3})?$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid routing number. This checks the length
     and characters in each position."""
     number = compact(number)
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid BIC."""
     try:
         return bool(validate(number))
@@ -82,6 +83,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/bitcoin.py
+++ b/stdnum/bitcoin.py
@@ -41,16 +41,18 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import hashlib
 import struct
 from functools import reduce
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').strip()
@@ -63,7 +65,7 @@ def compact(number):
 _base58_alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 
-def b58decode(s):
+def b58decode(s: str) -> bytes:
     """Decode a Base58 encoded string to a bytestring."""
     value = reduce(lambda a, c: a * 58 + _base58_alphabet.index(c), s, 0)
     result = b''
@@ -84,18 +86,18 @@ _bech32_generator = (
     (1 << 3, 0x3d4233dd), (1 << 4, 0x2a1462b3))
 
 
-def bech32_checksum(values):
+def bech32_checksum(values: t.Iterable[int]) -> int:
     """Calculate the Bech32 checksum."""
     chk = 1
     for value in values:
         top = chk >> 25
         chk = (chk & 0x1ffffff) << 5 | value
-        for t, v in _bech32_generator:
-            chk ^= v if top & t else 0
+        for test, val in _bech32_generator:
+            chk ^= val if top & test else 0
     return chk
 
 
-def b32decode(data):
+def b32decode(data: t.Iterable[int]) -> bytes:
     """Decode a list of Base32 values to a bytestring."""
     acc, bits = 0, 0
     result = b''
@@ -110,12 +112,12 @@ def b32decode(data):
     return result
 
 
-def _expand_hrp(hrp):
+def _expand_hrp(hrp: str) -> list[int]:
     """Convert the human-readable part to format for checksum calculation."""
     return [ord(c) >> 5 for c in hrp] + [0] + [ord(c) & 31 for c in hrp]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -150,7 +152,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:

--- a/stdnum/br/__init__.py
+++ b/stdnum/br/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Brazilian numbers."""
+from __future__ import annotations
+
 from stdnum.br import cnpj as vat  # noqa: F401

--- a/stdnum/br/cnpj.py
+++ b/stdnum/br/cnpj.py
@@ -37,18 +37,19 @@ InvalidFormat: ...
 >>> format('16727230000197')
 '16.727.230/0001-97'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -./').strip()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     d1 = (11 - sum(((3 - i) % 8 + 2) * int(n)
                    for i, n in enumerate(number[:12]))) % 11 % 10
@@ -58,7 +59,7 @@ def calc_check_digits(number):
     return '%d%d' % (d1, d2)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CNPJ. This checks the length and
     whether the check digits are correct."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CNPJ."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return (number[0:2] + '.' + number[2:5] + '.' + number[5:8] + '/' +

--- a/stdnum/br/cpf.py
+++ b/stdnum/br/cpf.py
@@ -41,18 +41,19 @@ InvalidFormat: ...
 >>> format('23100299900')
 '231.002.999-00'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip()
 
 
-def _calc_check_digits(number):
+def _calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     d1 = sum((10 - i) * int(number[i]) for i in range(9))
     d1 = (11 - d1) % 11 % 10
@@ -61,7 +62,7 @@ def _calc_check_digits(number):
     return '%d%d' % (d1, d2)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CPF. This checks the length and whether
     the check digit is correct."""
     number = compact(number)
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CPF."""
     try:
         return bool(validate(number))
@@ -82,7 +83,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:3] + '.' + number[3:6] + '.' + number[6:-2] + '-' + number[-2:]

--- a/stdnum/by/__init__.py
+++ b/stdnum/by/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Belarusian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.by import unp as vat  # noqa: F401

--- a/stdnum/by/unp.py
+++ b/stdnum/by/unp.py
@@ -40,6 +40,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -52,7 +53,7 @@ _cyrillic_to_latin = dict(zip(
 ))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -63,7 +64,7 @@ def compact(number):
     return ''.join(_cyrillic_to_latin.get(x, x) for x in number)
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     number = compact(number)
     alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -76,7 +77,7 @@ def calc_check_digit(number):
     return str(c)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -93,7 +94,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid number."""
     try:
         return bool(validate(number))
@@ -101,7 +102,7 @@ def is_valid(number):
         return False
 
 
-def check_nalog(number, timeout=30, verify=True):  # pragma: no cover (not part of normal test suite)
+def check_nalog(number, timeout=30, verify=True):  # type: ignore # pragma: no cover (not part of normal test suite)
     """Retrieve registration information from the portal.nalog.gov.by web site.
 
     The `timeout` argument specifies the network timeout in seconds.

--- a/stdnum/ca/__init__.py
+++ b/stdnum/ca/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Canadian numbers."""
+from __future__ import annotations
+
 from stdnum.ca import bn as vat  # noqa: F401

--- a/stdnum/ca/bc_phn.py
+++ b/stdnum/ca/bc_phn.py
@@ -54,19 +54,19 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """  # noqa: E501
-
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '- ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the check
     digit included."""
     weights = (2, 4, 8, 5, 10, 9, 7, 3)
@@ -74,7 +74,7 @@ def calc_check_digit(number):
     return str((11 - s) % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid PHN. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -89,7 +89,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid PHN."""
     try:
         return bool(validate(number))
@@ -97,7 +97,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[0:4], number[4:7], number[7:]))

--- a/stdnum/ca/bn.py
+++ b/stdnum/ca/bn.py
@@ -42,19 +42,20 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '- ').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid BN or BN15. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid BN or BN15."""
     try:
         return bool(validate(number))

--- a/stdnum/ca/sin.py
+++ b/stdnum/ca/sin.py
@@ -46,19 +46,20 @@ InvalidComponent: ...
 >>> format('123456782')
 '123-456-782'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '- ').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid SIN. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return luhn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid SIN."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[0:3], number[3:6], number[6:]))

--- a/stdnum/casrn.py
+++ b/stdnum/casrn.py
@@ -37,6 +37,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -47,7 +48,7 @@ from stdnum.util import clean
 _cas_re = re.compile(r'^[1-9][0-9]{1,6}-[0-9]{2}-[0-9]$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     number = clean(number, ' ').strip()
     if '-' not in number:
@@ -55,7 +56,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number. The passed number should not
     have the check digit included."""
     number = number.replace('-', '')
@@ -63,7 +64,7 @@ def calc_check_digit(number):
         sum((i + 1) * int(n) for i, n in enumerate(reversed(number))) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CAS RN."""
     number = compact(number)
     if not 7 <= len(number) <= 12:
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CAS RN."""
     try:
         return bool(validate(number))

--- a/stdnum/cfi.py
+++ b/stdnum/cfi.py
@@ -46,6 +46,7 @@ InvalidComponent: ...
   "group": "Limited partnership units"
 }
 """
+from __future__ import annotations
 
 from stdnum import numdb
 from stdnum.exceptions import *
@@ -56,13 +57,13 @@ from stdnum.util import clean
 _cfidb = numdb.get('cfi')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Look up information about the number."""
     number = compact(number)
     info = _cfidb.info(number)
@@ -79,7 +80,7 @@ def info(number):
     return properties
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     format."""
     number = compact(number)
@@ -91,7 +92,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:

--- a/stdnum/ch/esr.py
+++ b/stdnum/ch/esr.py
@@ -48,18 +48,19 @@ InvalidChecksum: ...
 >>> format('18 78583')
 '00 00000 00000 00000 00018 78583'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separators."""
     return clean(number, ' ').lstrip('0')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for number. The number passed should
     not have the check digit included."""
     _digits = (0, 9, 4, 6, 8, 2, 7, 1, 3, 5)
@@ -69,7 +70,7 @@ def calc_check_digit(number):
     return str((10 - c) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ESR. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ESR."""
     try:
         return bool(validate(number))
@@ -90,7 +91,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number).zfill(27)
     return number[:2] + ' ' + ' '.join(

--- a/stdnum/ch/ssn.py
+++ b/stdnum/ch/ssn.py
@@ -45,25 +45,26 @@ InvalidComponent: ...
 >>> format('7569217076985')
 '756.9217.0769.85'
 """
+from __future__ import annotations
 
 from stdnum import ean
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip()
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '.'.join((number[:3], number[3:7], number[7:11], number[11:]))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Swiss Sozialversicherungsnummer."""
     number = compact(number)
     if len(number) != 13:
@@ -73,7 +74,7 @@ def validate(number):
     return ean.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Swiss Sozialversicherungsnummer."""
     try:
         return bool(validate(number))

--- a/stdnum/ch/uid.py
+++ b/stdnum/ch/uid.py
@@ -45,12 +45,13 @@ InvalidChecksum: ...
 >>> format('CHE100155212')
 'CHE-100.155.212'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, get_soap_client, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separators."""
     number = clean(number, ' -.').strip().upper()
@@ -59,7 +60,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for organisations. The number passed should
     not have the check digit included."""
     weights = (5, 4, 3, 2, 7, 6, 5, 4)
@@ -67,7 +68,7 @@ def calc_check_digit(number):
     return str((11 - s) % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid UID. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid UID."""
     try:
         return bool(validate(number))
@@ -90,7 +91,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:3] + '-' + '.'.join(
@@ -100,7 +101,7 @@ def format(number):
 uid_wsdl = 'https://www.uid-wse.admin.ch/V5.0/PublicServices.svc?wsdl'
 
 
-def check_uid(number, timeout=30, verify=True):  # pragma: no cover
+def check_uid(number, timeout=30, verify=True):  # type: ignore # pragma: no cover
     """Look up information via the Swiss Federal Statistical Office web service.
 
     This uses the UID registry web service run by the the Swiss Federal

--- a/stdnum/ch/vat.py
+++ b/stdnum/ch/vat.py
@@ -42,18 +42,19 @@ InvalidChecksum: ...
 >>> format('CHE107787577IVA')
 'CHE-107.787.577 IVA'
 """
+from __future__ import annotations
 
 from stdnum.ch import uid
 from stdnum.exceptions import *
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separators."""
     return uid.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))
@@ -73,7 +74,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return uid.format(number[:12]) + ' ' + number[12:]

--- a/stdnum/cl/__init__.py
+++ b/stdnum/cl/__init__.py
@@ -19,6 +19,8 @@
 # 02110-1301 USA
 
 """Collection of Chilean numbers."""
+from __future__ import annotations
+
 
 # provide vat and run as an alias
 from stdnum.cl import rut as vat  # noqa: F401, isort:skip

--- a/stdnum/cl/rut.py
+++ b/stdnum/cl/rut.py
@@ -41,12 +41,13 @@ InvalidFormat: ...
 >>> format('125319092')
 '12.531.909-2'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -55,14 +56,14 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     s = sum(int(n) * (4 + (5 - i) % 6) for i, n in enumerate(number[::-1]))
     return '0123456789K'[s % 11]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid RUT. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid RUT."""
     try:
         return bool(validate(number))
@@ -83,7 +84,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return (number[:-7] + '.' + number[-7:-4] + '.' +

--- a/stdnum/cn/__init__.py
+++ b/stdnum/cn/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of China (PRC) numbers."""
+from __future__ import annotations
 
 # Provide vat as an alias.
 from stdnum.cn import uscc as vat  # noqa: F401

--- a/stdnum/cn/ric.py
+++ b/stdnum/cn/ric.py
@@ -31,6 +31,7 @@ digit is the checksum.
 >>> validate('360426199101010071')
 '360426199101010071'
 """
+from __future__ import annotations
 
 import datetime
 
@@ -38,13 +39,13 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number).upper().strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date.
     Note that in some cases it may return the registration date instead of
     the birth date and it may be a century off."""
@@ -58,7 +59,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_birth_place(number):
+def get_birth_place(number: str) -> dict[str, str]:
     """Use the number to look up the place of birth of the person."""
     from stdnum import numdb
     number = compact(number)
@@ -68,14 +69,14 @@ def get_birth_place(number):
     return results
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should have the check
     digit included."""
     checksum = (1 - 2 * int(number[:-1], 13)) % 11
     return 'X' if checksum == 10 else str(checksum)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid RIC number. This checks the length,
     formatting and birth date and place."""
     number = compact(number)
@@ -90,7 +91,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid RIC number."""
     try:
         return bool(validate(number))
@@ -98,6 +99,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/cn/uscc.py
+++ b/stdnum/cn/uscc.py
@@ -70,6 +70,7 @@ InvalidLength: ...
 >>> format('9 1 110000 600037341L')
 '91110000600037341L'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -78,7 +79,7 @@ from stdnum.util import clean, isdigits
 _alphabet = '0123456789ABCDEFGHJKLMNPQRTUWXY'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -87,7 +88,7 @@ def compact(number):
     return clean(number, ' -').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     weights = (1, 3, 9, 27, 19, 26, 16, 17, 20, 29, 25, 13, 8, 24, 10, 30, 28)
     number = compact(number)
@@ -95,7 +96,7 @@ def calc_check_digit(number):
     return _alphabet[(31 - total) % 31]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid USCC.
 
     This checks the length, formatting and check digit.
@@ -112,7 +113,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid USCC."""
     try:
         return bool(validate(number))
@@ -120,6 +121,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/co/__init__.py
+++ b/stdnum/co/__init__.py
@@ -19,6 +19,8 @@
 # 02110-1301 USA
 
 """Collection of Colombian numbers."""
+from __future__ import annotations
+
 
 # provide vat and rut as an alias
 from stdnum.co import nit as vat  # noqa: F401, isort:skip

--- a/stdnum/co/nit.py
+++ b/stdnum/co/nit.py
@@ -34,18 +34,19 @@ InvalidChecksum: ...
 >>> format('2131234321')
 '213.123.432-1'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, '.,- ').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     weights = (3, 7, 13, 17, 19, 23, 29, 37, 41, 43, 47, 53, 59, 67, 71)
@@ -53,7 +54,7 @@ def calc_check_digit(number):
     return '01987654321'[s]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid NIT. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid NIT."""
     try:
         return bool(validate(number))
@@ -74,7 +75,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '.'.join(

--- a/stdnum/cr/__init__.py
+++ b/stdnum/cr/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Costa Rican numbers."""
+from __future__ import annotations
+
 from stdnum.cr import cpj as vat  # noqa: F401

--- a/stdnum/cr/cpf.py
+++ b/stdnum/cr/cpf.py
@@ -52,12 +52,13 @@ InvalidLength: ...
 >>> format('1-613-584')
 '01-0613-0584'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -76,7 +77,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Costa Rica CPF number.
 
     This checks the length and formatting.
@@ -91,7 +92,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Costa Rica CPF number."""
     try:
         return bool(validate(number))
@@ -99,7 +100,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:2], number[2:6], number[6:]])

--- a/stdnum/cr/cpj.py
+++ b/stdnum/cr/cpj.py
@@ -48,12 +48,13 @@ InvalidLength: ...
 >>> format('4 000 042138')
 '4-000-042138'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -62,7 +63,7 @@ def compact(number):
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Costa Rica CPJ number.
 
     This checks the length and formatting.
@@ -89,7 +90,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Costa Rica CPJ number."""
     try:
         return bool(validate(number))
@@ -97,7 +98,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[0], number[1:4], number[4:]])

--- a/stdnum/cr/cr.py
+++ b/stdnum/cr/cr.py
@@ -50,12 +50,13 @@ InvalidLength: ...
 >>> format('122200569906')
 '122200569906'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -64,7 +65,7 @@ def compact(number):
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Costa Rica CR number.
 
     This checks the length and formatting.
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Costa Rica CR number."""
     try:
         return bool(validate(number))
@@ -87,6 +88,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/cu/ni.py
+++ b/stdnum/cu/ni.py
@@ -49,20 +49,22 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, ' ').strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the date of birth."""
     number = compact(number)
     year = int(number[0:2])
@@ -80,7 +82,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the gender (M/F) from the person's NI."""
     number = compact(number)
     if int(number[9]) % 2:
@@ -89,7 +91,7 @@ def get_gender(number):
         return 'M'
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid NI. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -101,7 +103,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid NI."""
     try:
         return bool(validate(number))

--- a/stdnum/cusip.py
+++ b/stdnum/cusip.py
@@ -38,12 +38,13 @@ InvalidChecksum: ...
 >>> to_isin('91324PAE2')
 'US91324PAE25'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
@@ -52,7 +53,7 @@ def compact(number):
 _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*@#'
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digits for the number."""
     # convert to numeric first, then sum individual digits
     number = ''.join(
@@ -60,7 +61,7 @@ def calc_check_digit(number):
     return str((10 - sum(int(n) for n in number)) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -73,7 +74,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:
@@ -82,7 +83,7 @@ def is_valid(number):
         return False
 
 
-def to_isin(number):
+def to_isin(number: str) -> str:
     """Convert the number to an ISIN."""
     from stdnum import isin
     return isin.from_natid('US', number)

--- a/stdnum/cy/vat.py
+++ b/stdnum/cy/vat.py
@@ -32,12 +32,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -46,7 +47,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     translation = {
@@ -59,7 +60,7 @@ def calc_check_digit(number):
     ) % 26]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/cz/__init__.py
+++ b/stdnum/cz/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Czech numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.cz import dic as vat  # noqa: F401

--- a/stdnum/cz/bankaccount.py
+++ b/stdnum/cz/bankaccount.py
@@ -47,6 +47,7 @@ InvalidComponent: ...
 >>> to_bic('34278-727558021/0100')
 'KOMBCZPP'
 """
+from __future__ import annotations
 
 import re
 
@@ -58,7 +59,7 @@ _bankaccount_re = re.compile(
     r'((?P<prefix>[0-9]{0,6})-)?(?P<root>[0-9]{2,10})\/(?P<bank>[0-9]{4})')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number).strip()
@@ -71,7 +72,7 @@ def compact(number):
     return number
 
 
-def _split(number):
+def _split(number: str) -> tuple[str | None, str, str]:
     """Split valid numbers into prefix, root and bank parts of the number."""
     match = _bankaccount_re.match(number)
     if not match:
@@ -79,7 +80,7 @@ def _split(number):
     return match.group('prefix'), match.group('root'), match.group('bank')
 
 
-def _info(bank):
+def _info(bank: str) -> dict[str, str]:
     """Look up information for the bank."""
     from stdnum import numdb
     info = {}
@@ -88,29 +89,29 @@ def _info(bank):
     return info
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Return a dictionary of data about the supplied number. This typically
     returns the name of the bank and branch and a BIC if it is valid."""
     prefix, root, bank = _split(compact(number))
     return _info(bank)
 
 
-def to_bic(number):
+def to_bic(number: str) -> str | None:
     """Return the BIC for the bank that this number refers to."""
-    bic = info(number).get('bic')
-    if bic:
-        return str(bic)
+    return info(number).get('bic')
 
 
-def _calc_checksum(number):
+def _calc_checksum(number: str) -> int:
     weights = (6, 3, 7, 9, 10, 5, 8, 4, 2, 1)
     return sum(w * int(n) for w, n in zip(weights, number.zfill(10))) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid bank account number."""
     number = compact(number)
     prefix, root, bank = _split(number)
+    # guaranteed to be present if compact is called and _split doesn't raise
+    assert prefix
     if _calc_checksum(prefix) != 0:
         raise InvalidChecksum()
     if _calc_checksum(root) != 0:
@@ -120,7 +121,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid bank account number."""
     try:
         return bool(validate(number))
@@ -128,6 +129,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/cz/dic.py
+++ b/stdnum/cz/dic.py
@@ -39,13 +39,14 @@ InvalidChecksum: ...
 >>> validate('640903926')  # special case
 '640903926'
 """
+from __future__ import annotations
 
 from stdnum.cz import rc
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' /').upper().strip()
@@ -54,21 +55,21 @@ def compact(number):
     return number
 
 
-def calc_check_digit_legal(number):
+def calc_check_digit_legal(number: str) -> str:
     """Calculate the check digit for 8 digit legal entities. The number
     passed should not have the check digit included."""
     check = (11 - sum((8 - i) * int(n) for i, n in enumerate(number))) % 11
     return str((check or 1) % 10)
 
 
-def calc_check_digit_special(number):
+def calc_check_digit_special(number: str) -> str:
     """Calculate the check digit for special cases. The number passed
     should not have the first and last digits included."""
     check = sum((8 - i) * int(n) for i, n in enumerate(number)) % 11
     return str((8 - (10 - check) % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -92,7 +93,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/cz/rc.py
+++ b/stdnum/cz/rc.py
@@ -46,6 +46,7 @@ InvalidLength: ...
 >>> format('7103192745')
 '710319/2745'
 """
+from __future__ import annotations
 
 import datetime
 
@@ -53,13 +54,13 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' /').upper().strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     year = 1900 + int(number[0:2])
@@ -81,7 +82,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid birth number. This checks the length,
     formatting, embedded date and check digit."""
     number = compact(number)
@@ -103,7 +104,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid birth number."""
     try:
         return bool(validate(number))
@@ -111,7 +112,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:6] + '/' + number[6:]

--- a/stdnum/damm.py
+++ b/stdnum/damm.py
@@ -52,9 +52,13 @@ InvalidChecksum: ...
 >>> checksum('816', table=table)
 9
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 
+
+Table: t.TypeAlias = 't.Sequence[t.Sequence[int]]'
 
 _operation_table = (
     (0, 3, 1, 7, 5, 9, 8, 6, 4, 2),
@@ -69,7 +73,7 @@ _operation_table = (
     (2, 5, 8, 1, 4, 3, 6, 7, 9, 0))
 
 
-def checksum(number, table=None):
+def checksum(number: str, table: Table | None = None) -> int:
     """Calculate the Damm checksum over the provided number. The checksum is
     returned as an integer value and should be 0 when valid."""
     table = table or _operation_table
@@ -79,7 +83,7 @@ def checksum(number, table=None):
     return i
 
 
-def validate(number, table=None):
+def validate(number: str, table: Table | None = None) -> str:
     """Check if the number provided passes the Damm algorithm."""
     if not bool(number):
         raise InvalidFormat()
@@ -92,7 +96,7 @@ def validate(number, table=None):
     return number
 
 
-def is_valid(number, table=None):
+def is_valid(number: str, table: Table | None = None) -> bool:
     """Check if the number provided passes the Damm algorithm."""
     try:
         return bool(validate(number, table=table))
@@ -100,7 +104,7 @@ def is_valid(number, table=None):
         return False
 
 
-def calc_check_digit(number, table=None):
+def calc_check_digit(number: str, table: Table | None = None) -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     return str(checksum(number, table=table))

--- a/stdnum/de/__init__.py
+++ b/stdnum/de/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of German numbers."""
+from __future__ import annotations
 
 # provide businessid as an alias
 from stdnum.de import handelsregisternummer as businessid  # noqa: F401

--- a/stdnum/de/handelsregisternummer.py
+++ b/stdnum/de/handelsregisternummer.py
@@ -49,10 +49,12 @@ Traceback (most recent call last):
   ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import re
 import unicodedata
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean
 
@@ -213,7 +215,7 @@ GERMAN_COURTS = (
 )
 
 
-def _to_min(court):
+def _to_min(court: str) -> str:
     """Convert the court name for quick comparison without encoding issues."""
     return ''.join(
         x for x in unicodedata.normalize('NFD', court.lower())
@@ -280,7 +282,7 @@ _formats = [
 ]
 
 
-def _split(number):
+def _split(number: str) -> tuple[str, str, str, str | None]:
     """Split the number into a court, registry, register number and
     optionally qualifier."""
     number = clean(number).strip()
@@ -291,17 +293,18 @@ def _split(number):
     raise InvalidFormat()
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     court, registry, number, qualifier = _split(number)
     return ' '.join(x for x in [court, registry, number, qualifier] if x)
 
 
-def validate(number, company_form=None):
+def validate(number: str, company_form: str | None = None) -> str:
     """Check if the number is a valid company registry number. If a
     company_form (eg. GmbH or PartG) is given, the number is validated to
     have the correct registry type."""
+    court: str | None
     court, registry, number, qualifier = _split(number)
     court = _courts.get(_to_min(court))
     if not court:
@@ -311,7 +314,7 @@ def validate(number, company_form=None):
     return ' '.join(x for x in [court, registry, number, qualifier] if x)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid company registry number."""
     try:
         return bool(validate(number))
@@ -323,7 +326,11 @@ def is_valid(number):
 _offeneregister_url = 'https://db.offeneregister.de/openregister.json'
 
 
-def check_offeneregister(number, timeout=30, verify=True):  # pragma: no cover (not part of normal test suite)
+def check_offeneregister(
+    number: str,
+    timeout: float = 30,
+    verify: bool = True,
+) -> dict[str, t.Any] | None:  # pragma: no cover (not part of normal test suite)
     """Retrieve registration information from the OffeneRegister.de web site.
 
     The `timeout` argument specifies the network timeout in seconds.
@@ -373,4 +380,4 @@ def check_offeneregister(number, timeout=30, verify=True):  # pragma: no cover (
         json = response.json()
         return dict(zip(json['columns'], json['rows'][0]))
     except (KeyError, IndexError) as e:  # noqa: F841
-        return  # number not found
+        return None  # number not found

--- a/stdnum/de/idnr.py
+++ b/stdnum/de/idnr.py
@@ -44,6 +44,7 @@ InvalidFormat: ...
 >>> format('36574261809')
 '36 574 261 809'
 """
+from __future__ import annotations
 
 from collections import defaultdict
 
@@ -52,13 +53,13 @@ from stdnum.iso7064 import mod_11_10
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -./,').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid tax identification number.
     This checks the length, formatting and check digit."""
     number = compact(number)
@@ -70,7 +71,7 @@ def validate(number):
         raise InvalidFormat()
     # In the first 10 digits exactly one digit must be repeated two or
     # three times and other digits can appear only once.
-    counter = defaultdict(int)
+    counter: dict[str, int] = defaultdict(int)
     for n in number[:10]:
         counter[n] += 1
     counts = [c for c in counter.values() if c > 1]
@@ -79,7 +80,7 @@ def validate(number):
     return mod_11_10.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid tax identification number.
     This checks the length, formatting and check digit."""
     try:
@@ -88,7 +89,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:2], number[2:5], number[5:8], number[8:]))

--- a/stdnum/de/stnr.py
+++ b/stdnum/de/stnr.py
@@ -49,15 +49,17 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 import re
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
 # The number formats per region (regional and country-wide format)
-_number_formats_per_region = {
+_number_formats_per_region_raw = {
     'Baden-Württemberg': ['FFBBBUUUUP', '28FF0BBBUUUUP'],
     'Bayern': ['FFFBBBUUUUP', '9FFF0BBBUUUUP'],
     'Berlin': ['FFBBBUUUUP', '11FF0BBBUUUUP'],
@@ -76,11 +78,11 @@ _number_formats_per_region = {
     'Thüringen': ['1FFBBBUUUUP', '41FF0BBBUUUUP'],
 }
 
-REGIONS = sorted(_number_formats_per_region.keys())
+REGIONS = sorted(_number_formats_per_region_raw.keys())
 """Valid regions recognised by this module."""
 
 
-def _clean_region(region):
+def _clean_region(region: str) -> str:
     """Convert the region name to something that we can use for comparison
     without running into encoding issues."""
     return ''.join(
@@ -90,28 +92,28 @@ def _clean_region(region):
 
 class _Format():
 
-    def __init__(self, fmt):
+    def __init__(self, fmt: str) -> None:
         self._fmt = fmt
         self._re = re.compile('^%s$' % re.sub(
             r'([FBUP])\1*',
             lambda x: r'(\d{%d})' % len(x.group(0)), fmt))
 
-    def match(self, number):
+    def match(self, number: str) -> re.Match[str] | None:
         return self._re.match(number)
 
-    def replace(self, f, b, u, p):
+    def replace(self, f: str, b: str, u: str, p: str) -> str:
         items = iter([f, b, u, p])
         return re.sub(r'([FBUP])\1*', lambda x: next(items), self._fmt)
 
 
 # Convert the structure to something that we can easily use
 _number_formats_per_region = dict(
-    (_clean_region(region), [
-        region, _Format(formats[0]), _Format(formats[1])])
-    for region, formats in _number_formats_per_region.items())
+    (_clean_region(region), (
+        region, _Format(formats[0]), _Format(formats[1])))
+    for region, formats in _number_formats_per_region_raw.items())
 
 
-def _get_formats(region=None):
+def _get_formats(region: str | None = None) -> t.Iterable[tuple[str, _Format, _Format]]:
     """Return the formats for the region."""
     if region:
         region = _clean_region(region)
@@ -121,13 +123,13 @@ def _get_formats(region=None):
     return _number_formats_per_region.values()
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -./,').strip()
 
 
-def validate(number, region=None):
+def validate(number: str, region: str | None = None) -> str:
     """Check if the number is a valid tax number. This checks the length and
     formatting. The region can be supplied to verify that the number is
     assigned in that region."""
@@ -142,7 +144,7 @@ def validate(number, region=None):
     return number
 
 
-def is_valid(number, region=None):
+def is_valid(number: str, region: str | None = None) -> bool:
     """Check if the number is a valid tax number. This checks the length and
     formatting. The region can be supplied to verify that the number is
     assigned in that region."""
@@ -152,7 +154,7 @@ def is_valid(number, region=None):
         return False
 
 
-def guess_regions(number):
+def guess_regions(number: str) -> list[str]:
     """Return a list of regions this number is valid for."""
     number = compact(number)
     return sorted(
@@ -160,7 +162,7 @@ def guess_regions(number):
         if region_fmt.match(number) or country_fmt.match(number))
 
 
-def to_regional_number(number):
+def to_regional_number(number: str) -> str:
     """Convert the number to a regional (10 or 11 digit) number."""
     number = compact(number)
     for _region, region_fmt, country_fmt in _get_formats():
@@ -170,16 +172,16 @@ def to_regional_number(number):
     raise InvalidFormat()
 
 
-def to_country_number(number, region=None):
+def to_country_number(number: str, region: str | None = None) -> str:
     """Convert the number to the nationally unique number. The region is
     needed if the number is not only valid for one particular region."""
     number = compact(number)
-    formats = (
+    formats_iter = (
         (region_fmt.match(number), country_fmt)
         for _region, region_fmt, country_fmt in _get_formats(region))
     formats = [
         (region_match, country_fmt)
-        for region_match, country_fmt in formats
+        for region_match, country_fmt in formats_iter
         if region_match]
     if not formats:
         raise InvalidFormat()
@@ -188,7 +190,7 @@ def to_country_number(number, region=None):
     return formats[0][1].replace(*formats[0][0].groups())
 
 
-def format(number, region=None):
+def format(number: str, region: str | None = None) -> str:
     """Reformat the passed number to the standard format."""
     number = compact(number)
     for _region, region_fmt, _country_fmt in _get_formats(region):

--- a/stdnum/de/vat.py
+++ b/stdnum/de/vat.py
@@ -31,13 +31,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_11_10
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -./,').upper().strip()
@@ -46,7 +47,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -58,7 +59,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/de/wkn.py
+++ b/stdnum/de/wkn.py
@@ -33,12 +33,13 @@ InvalidFormat: ...
 >>> to_isin('SKWM02')
 'DE000SKWM021'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
@@ -48,7 +49,7 @@ def compact(number):
 _alphabet = '0123456789ABCDEFGH JKLMN PQRSTUVWXYZ'
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -59,7 +60,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:
@@ -68,7 +69,7 @@ def is_valid(number):
         return False
 
 
-def to_isin(number):
+def to_isin(number: str) -> str:
     """Convert the number to an ISIN."""
     from stdnum import isin
     return isin.from_natid('DE', number)

--- a/stdnum/dk/__init__.py
+++ b/stdnum/dk/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Danish numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.dk import cpr as personalid  # noqa: F401

--- a/stdnum/dk/cpr.py
+++ b/stdnum/dk/cpr.py
@@ -55,6 +55,7 @@ datetime.date(1962, 10, 21)
 >>> format('2110625629')
 '211062-5629'
 """
+from __future__ import annotations
 
 import datetime
 
@@ -62,20 +63,20 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. Note that the checksum isn't actually used
     any more. Valid numbers used to have a checksum of 0."""
     weights = (4, 3, 2, 7, 6, 5, 4, 3, 2, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     day = int(number[0:2])
@@ -93,7 +94,7 @@ def get_birth_date(number):
         raise InvalidComponent('The number does not contain valid birth date information.')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CPR number. This checks the
     length, formatting, embedded date and check digit."""
     number = compact(number)
@@ -107,7 +108,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CPR number. This checks the
     length, formatting, embedded date and check digit."""
     try:
@@ -116,7 +117,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[:6], number[6:]))

--- a/stdnum/dk/cvr.py
+++ b/stdnum/dk/cvr.py
@@ -29,12 +29,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.,/:').upper().strip()
@@ -43,13 +44,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (2, 7, 6, 5, 4, 3, 2, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -62,7 +63,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/do/__init__.py
+++ b/stdnum/do/__init__.py
@@ -19,5 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Dominican Republic numbers."""
+from __future__ import annotations
 
 from stdnum.do import rnc as vat  # noqa: F401

--- a/stdnum/do/cedula.py
+++ b/stdnum/do/cedula.py
@@ -36,7 +36,9 @@ InvalidFormat: ...
 >>> format('22400022111')
 '224-0002211-1'
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum import luhn
 from stdnum.do import rnc
 from stdnum.exceptions import *
@@ -145,13 +147,13 @@ whitelist = set('''
 '''.split())
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid cedula."""
     number = compact(number)
     if not isdigits(number):
@@ -163,7 +165,7 @@ def validate(number):
     return luhn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid cedula."""
     try:
         return bool(validate(number))
@@ -171,13 +173,13 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[:3], number[3:-1], number[-1]))
 
 
-def check_dgii(number, timeout=30):  # pragma: no cover
+def check_dgii(number: str, timeout: float = 30) -> dict[str, t.Any] | None:  # pragma: no cover
     """Lookup the number using the DGII online web service.
 
     This uses the validation service run by the the Dirección General de

--- a/stdnum/do/ncf.py
+++ b/stdnum/do/ncf.py
@@ -55,12 +55,14 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
@@ -95,7 +97,7 @@ _ecf_document_types = (
 )
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid NCF."""
     number = compact(number)
     if len(number) == 13:
@@ -118,7 +120,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid NCF."""
     try:
         return bool(validate(number))
@@ -126,7 +128,7 @@ def is_valid(number):
         return False
 
 
-def _convert_result(result):  # pragma: no cover
+def _convert_result(result: t.Mapping[str, str]) -> dict[str, str]:  # pragma: no cover
     """Translate SOAP result entries into dictionaries."""
     translation = {
         'NOMBRE': 'name',
@@ -157,7 +159,14 @@ def _convert_result(result):  # pragma: no cover
         for key, value in result.items())
 
 
-def check_dgii(rnc, ncf, buyer_rnc=None, security_code=None, timeout=30, verify=True):  # pragma: no cover
+def check_dgii(
+    rnc: str,
+    ncf: str,
+    buyer_rnc: str | None = None,
+    security_code: str | None = None,
+    timeout: float = 30,
+    verify: bool = True,
+) -> dict[str, str] | None:  # pragma: no cover
     """Validate the RNC, NCF combination on using the DGII online web service.
 
     This uses the validation service run by the the Dirección General de
@@ -198,7 +207,7 @@ def check_dgii(rnc, ncf, buyer_rnc=None, security_code=None, timeout=30, verify=
         }
 
     Will return None if the number is invalid or unknown."""
-    import lxml.html
+    import lxml.html  # type: ignore
     import requests
     from stdnum.do.rnc import compact as rnc_compact  # noqa: I003
     rnc = rnc_compact(rnc)
@@ -240,3 +249,4 @@ def check_dgii(rnc, ncf, buyer_rnc=None, security_code=None, timeout=30, verify=
             [x.text.strip() for x in result.findall('.//th') if x.text],
             [x.text.strip() for x in result.findall('.//td/span') if x.text]))
         return _convert_result(data)
+    return None

--- a/stdnum/dz/__init__.py
+++ b/stdnum/dz/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Algerian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.dz import nif as vat  # noqa: F401

--- a/stdnum/dz/nif.py
+++ b/stdnum/dz/nif.py
@@ -59,12 +59,13 @@ InvalidFormat: ...
 >>> format('000 216 001 808 337 13010')
 '00021600180833713010'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators, removes surrounding
@@ -73,7 +74,7 @@ def compact(number):
     return clean(number, ' ')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Algeria NIF number.
 
     This checks the length and formatting.
@@ -86,7 +87,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Algeria NIF number."""
     try:
         return bool(validate(number))
@@ -94,6 +95,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/ean.py
+++ b/stdnum/ean.py
@@ -29,25 +29,26 @@ module handles numbers EAN-13, EAN-8, UPC (12-digit) and GTIN (EAN-14) format.
 >>> validate('98412345678908') # GTIN format
 '98412345678908'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the EAN to the minimal representation. This strips the number
     of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the EAN check digit for 13-digit numbers. The number passed
     should not have the check bit included."""
     return str((10 - sum((3, 1)[i % 2] * int(n)
                          for i, n in enumerate(reversed(number)))) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid EAN-13. This checks the length
     and the check bit but does not check whether a known GS1 Prefix and
     company identifier are referenced."""
@@ -61,7 +62,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid EAN-13. This checks the length
     and the check bit but does not check whether a known GS1 Prefix and
     company identifier are referenced."""

--- a/stdnum/ec/__init__.py
+++ b/stdnum/ec/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Ecuadorian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ec import ruc as vat  # noqa: F401

--- a/stdnum/ec/ci.py
+++ b/stdnum/ec/ci.py
@@ -34,25 +34,27 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def _checksum(number):
+def _checksum(number: str) -> int:
     """Calculate a checksum over the number."""
-    fold = lambda x: x - 9 if x > 9 else x
+    def fold(x: int) -> int:
+        return x - 9 if x > 9 else x
     return sum(fold((2, 1)[i % 2] * int(n))
                for i, n in enumerate(number)) % 10
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CI number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -69,7 +71,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CI number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/ec/ruc.py
+++ b/stdnum/ec/ruc.py
@@ -35,7 +35,9 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.ec import ci
 from stdnum.exceptions import *
 from stdnum.util import isdigits
@@ -48,12 +50,12 @@ __all__ = ['compact', 'validate', 'is_valid']
 compact = ci.compact
 
 
-def _checksum(number, weights):
+def _checksum(number: str, weights: t.Iterable[int]) -> int:
     """Calculate a checksum over the number given the weights."""
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def _validate_natural(number):
+def _validate_natural(number: str) -> str:
     """Check if the number is a valid natural RUC (CI plus establishment)."""
     if number[-3:] == '000':
         raise InvalidComponent()  # establishment number wrong
@@ -61,7 +63,7 @@ def _validate_natural(number):
     return number
 
 
-def _validate_public(number):
+def _validate_public(number: str) -> str:
     """Check if the number is a valid public RUC."""
     if number[-4:] == '0000':
         raise InvalidComponent()  # establishment number wrong
@@ -70,7 +72,7 @@ def _validate_public(number):
     return number
 
 
-def _validate_juridical(number):
+def _validate_juridical(number: str) -> str:
     """Check if the number is a valid juridical RUC."""
     if number[-3:] == '000':
         raise InvalidComponent()  # establishment number wrong
@@ -79,7 +81,7 @@ def _validate_juridical(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid RUC number. This checks the
     length, formatting, check digit and check sum."""
     number = compact(number)
@@ -109,7 +111,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid RUC number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/ee/__init__.py
+++ b/stdnum/ee/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Estonian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ee import kmkr as vat  # noqa: F401

--- a/stdnum/ee/ik.py
+++ b/stdnum/ee/ik.py
@@ -38,20 +38,22 @@ InvalidChecksum: ...
 >>> get_birth_date('36805280109')
 datetime.date(1968, 5, 28)
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     if number[0] in '12':
@@ -73,7 +75,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if number[0] in '1357':
@@ -84,7 +86,7 @@ def get_gender(number):
         raise InvalidComponent()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     check = sum(((i % 9) + 1) * int(n)
                 for i, n in enumerate(number[:-1])) % 11
@@ -94,7 +96,7 @@ def calc_check_digit(number):
     return str(check % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length,
     formatting, embedded date and check digit."""
     number = compact(number)
@@ -108,7 +110,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length,
     formatting, embedded date and check digit."""
     try:

--- a/stdnum/ee/kmkr.py
+++ b/stdnum/ee/kmkr.py
@@ -29,12 +29,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -43,13 +44,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (3, 7, 1, 3, 7, 1, 3, 7, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 10
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -62,7 +63,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/ee/registrikood.py
+++ b/stdnum/ee/registrikood.py
@@ -46,19 +46,20 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 from stdnum.ee.ik import calc_check_digit
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -73,7 +74,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:

--- a/stdnum/eg/__init__.py
+++ b/stdnum/eg/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Egypt numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.eg import tn as vat  # noqa: F401

--- a/stdnum/eg/tn.py
+++ b/stdnum/eg/tn.py
@@ -43,6 +43,7 @@ InvalidFormat: ...
 >>> format('100531385')
 '100-531-385'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -74,7 +75,7 @@ _ARABIC_NUMBERS_MAP = {
 }
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -83,7 +84,7 @@ def compact(number):
     return ''.join((_ARABIC_NUMBERS_MAP.get(c, c) for c in clean(number, ' -/').strip()))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Egypt Tax Number number.
 
     This checks the length and formatting.
@@ -96,7 +97,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Egypt Tax Number number."""
     try:
         return bool(validate(number))
@@ -104,7 +105,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:3], number[3:-3], number[-3:]])

--- a/stdnum/es/__init__.py
+++ b/stdnum/es/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Spanish numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.es import nif as vat  # noqa: F401

--- a/stdnum/es/cae.py
+++ b/stdnum/es/cae.py
@@ -49,6 +49,7 @@ False
 >>> compact('ES00008V1488Q')
 'ES00008V1488Q'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -203,13 +204,13 @@ _ACTIVITY_KEYS = {
 }
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number).upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CAE number. This checks the
     length and formatting."""
     number = compact(number)
@@ -230,7 +231,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CAE number. This checks the
     length and formatting."""
     try:

--- a/stdnum/es/ccc.py
+++ b/stdnum/es/ccc.py
@@ -61,18 +61,19 @@ InvalidChecksum: ...
 >>> to_iban('21000418450200051331')
 'ES2121000418450200051331'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join([
@@ -84,13 +85,13 @@ def format(number):
     ])
 
 
-def _calc_check_digit(number):
+def _calc_check_digit(number: str) -> str:
     """Calculate a single check digit on the provided part of the number."""
     check = sum(int(n) * 2 ** i for i, n in enumerate(number)) % 11
     return str(check if check < 2 else 11 - check)
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number. The supplied number should
     have check digits included but are ignored."""
     number = compact(number)
@@ -98,7 +99,7 @@ def calc_check_digits(number):
         _calc_check_digit('00' + number[:8]) + _calc_check_digit(number[10:]))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CCC."""
     number = compact(number)
     if len(number) != 20:
@@ -110,7 +111,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CCC."""
     try:
         return bool(validate(number))
@@ -118,7 +119,7 @@ def is_valid(number):
         return False
 
 
-def to_iban(number):
+def to_iban(number: str) -> str:
     """Convert the number to an IBAN."""
     from stdnum import iban
     separator = ' ' if ' ' in number else ''

--- a/stdnum/es/cif.py
+++ b/stdnum/es/cif.py
@@ -49,6 +49,7 @@ InvalidFormat: ...
 >>> split('A13 585 625')
 ('A', '13', '58562', '5')
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.es import dni
@@ -63,7 +64,7 @@ __all__ = ['compact', 'validate', 'is_valid', 'split']
 compact = dni.compact
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the specified number. The number
     passed should not have the check digit included. This function returns
     both the number and character check digit candidates."""
@@ -71,7 +72,7 @@ def calc_check_digits(number):
     return check + 'JABCDEFGHI'[int(check)]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid DNI number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -91,7 +92,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid DNI number. This checks the
     length, formatting and check digit."""
     try:
@@ -100,7 +101,7 @@ def is_valid(number):
         return False
 
 
-def split(number):
+def split(number: str) -> tuple[str, str, str, str]:
     """Split the provided number into a letter to define the type of
     organisation, two digits that specify a province, a 5 digit sequence
     number within the province and a check digit."""

--- a/stdnum/es/cups.py
+++ b/stdnum/es/cups.py
@@ -52,18 +52,19 @@ InvalidChecksum: ...
 >>> format('ES1234123456789012JY1F')
 'ES 1234 1234 5678 9012 JY 1F'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((
@@ -77,14 +78,14 @@ def format(number):
     )).strip()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     alphabet = 'TRWAGMYFPDXBNJZSQVHLCKE'
     check0, check1 = divmod(int(number[2:18]) % 529, 23)
     return alphabet[check0] + alphabet[check1]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CUPS. This checks length,
     formatting and check digits."""
     number = compact(number)
@@ -94,8 +95,8 @@ def validate(number):
         raise InvalidComponent()
     if not isdigits(number[2:18]):
         raise InvalidFormat()
-    if number[20:]:
-        pnumber, ptype = number[20:]
+    if len(number) == 22:
+        pnumber, ptype = number[20], number[21]
         if not isdigits(pnumber):
             raise InvalidFormat()
         if ptype not in 'FPRCXYZ':
@@ -105,7 +106,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CUPS."""
     try:
         return bool(validate(number))

--- a/stdnum/es/dni.py
+++ b/stdnum/es/dni.py
@@ -37,24 +37,25 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     return 'TRWAGMYFPDXBNJZSQVHLCKE'[int(number) % 23]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid DNI number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -67,7 +68,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid DNI number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/es/iban.py
+++ b/stdnum/es/iban.py
@@ -43,6 +43,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum import iban
 from stdnum.es import ccc
@@ -56,7 +57,7 @@ compact = iban.compact
 format = iban.format
 
 
-def to_ccc(number):
+def to_ccc(number: str) -> str:
     """Return the CCC (Código Cuenta Corriente) part of the number."""
     number = compact(number)
     if not number.startswith('ES'):
@@ -64,14 +65,14 @@ def to_ccc(number):
     return number[4:]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Spanish IBAN."""
     number = iban.validate(number, check_country=False)
     ccc.validate(to_ccc(number))
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Spanish IBAN."""
     try:
         return bool(validate(number))

--- a/stdnum/es/nie.py
+++ b/stdnum/es/nie.py
@@ -39,6 +39,7 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.es import dni
 from stdnum.exceptions import *
@@ -52,7 +53,7 @@ __all__ = ['compact', 'calc_check_digit', 'validate', 'is_valid']
 compact = dni.compact
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     # replace XYZ with 012
@@ -60,7 +61,7 @@ def calc_check_digit(number):
     return dni.calc_check_digit(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid NIE. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -73,7 +74,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid NIE. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/es/nif.py
+++ b/stdnum/es/nif.py
@@ -43,13 +43,14 @@ InvalidChecksum: ...
 >>> validate('M-1234567-L')  # foreign person without NIE
 'M1234567L'
 """
+from __future__ import annotations
 
 from stdnum.es import cif, dni, nie
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -58,7 +59,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -85,7 +86,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/es/postal_code.py
+++ b/stdnum/es/postal_code.py
@@ -53,18 +53,18 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
-
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     return clean(number, ' ').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid postal code."""
     number = compact(number)
     if len(number) != 5:
@@ -76,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid postal code."""
     try:
         return bool(validate(number))

--- a/stdnum/es/referenciacatastral.py
+++ b/stdnum/es/referenciacatastral.py
@@ -53,6 +53,7 @@ InvalidChecksum: ...
 >>> format('4A08169P03PRAT0001LR')  # BCN Airport
 '4A08169 P03PRAT 0001 LR'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
@@ -61,13 +62,13 @@ from stdnum.util import clean
 alphabet = 'ABCDEFGHIJKLMNÑOPQRSTUVWXYZ0123456789'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join([
@@ -81,7 +82,7 @@ def format(number):
 # implementation by Vicente Sancho that can be found at
 # https://trellat.es/validar-la-referencia-catastral-en-javascript/
 
-def _check_digit(number):
+def _check_digit(number: str) -> str:
     """Calculate a single check digit on the provided part of the number."""
     weights = (13, 15, 12, 5, 4, 17, 9, 21, 3, 7, 1)
     s = sum(w * (int(n) if n.isdigit() else alphabet.find(n) + 1)
@@ -89,7 +90,7 @@ def _check_digit(number):
     return 'MQWERTYUIOPASDFGHJKLBZX'[s % 23]
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     number = compact(number)
     return (
@@ -97,7 +98,7 @@ def calc_check_digits(number):
         _check_digit(number[7:14] + number[14:18]))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Cadastral Reference. This checks the
     length, formatting and check digits."""
     number = compact(number)
@@ -110,7 +111,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Cadastral Reference."""
     try:
         return bool(validate(number))

--- a/stdnum/eu/at_02.py
+++ b/stdnum/eu/at_02.py
@@ -37,6 +37,7 @@ contains the country-specific identifier.
 >>> calc_check_digits('ESXXZZZ47690558N')
 '23'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
@@ -47,20 +48,20 @@ from stdnum.util import clean
 _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the AT-02 number to the minimal representation. This strips
     the number of any valid separators and removes invalid characters."""
     return clean(number, ' -/?:().m\'+"').strip().upper()
 
 
-def _to_base10(number):
+def _to_base10(number: str) -> str:
     """Prepare the number to its base10 representation so it can be checked
     with the ISO 7064 Mod 97, 10 algorithm. That means excluding positions 5
     to 7 and moving the first four digits to the end."""
     return ''.join(str(_alphabet.index(x)) for x in number[7:] + number[:4])
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid AT-02."""
     number = compact(number)
     try:
@@ -72,7 +73,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid AT-02."""
     try:
         return bool(validate(number))
@@ -80,7 +81,7 @@ def is_valid(number):
         return False
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits that should be put in the number to make it
     valid. Check digits in the supplied number are ignored."""
     number = compact(number)

--- a/stdnum/eu/banknote.py
+++ b/stdnum/eu/banknote.py
@@ -33,24 +33,25 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').upper().strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum over the number."""
     # replace letters by their ASCII number
     return sum(int(x) if isdigits(x) else ord(x) for x in number) % 9
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid banknote serial number."""
     number = compact(number)
     if not number[:2].isalnum() or not isdigits(number[2:]):
@@ -64,7 +65,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid banknote serial number."""
     try:
         return bool(validate(number))

--- a/stdnum/eu/ecnumber.py
+++ b/stdnum/eu/ecnumber.py
@@ -37,6 +37,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -47,7 +48,7 @@ from stdnum.util import clean
 _ec_number_re = re.compile(r'^[0-9]{3}-[0-9]{3}-[0-9]$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     number = clean(number, ' ').strip()
     if '-' not in number:
@@ -55,7 +56,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number. The passed number should not
     have the check digit included."""
     number = compact(number).replace('-', '')
@@ -63,7 +64,7 @@ def calc_check_digit(number):
         sum((i + 1) * int(n) for i, n in enumerate(number)) % 11)[0]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid EC Number."""
     number = compact(number)
     if not len(number) == 9:
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid EC Number."""
     try:
         return bool(validate(number))

--- a/stdnum/eu/eic.py
+++ b/stdnum/eu/eic.py
@@ -43,6 +43,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
@@ -51,20 +52,20 @@ from stdnum.util import clean
 _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding white space."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     number = compact(number)
     s = sum((16 - i) * _alphabet.index(n) for i, n in enumerate(number[:15]))
     return _alphabet[36 - ((s - 1) % 37)]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is valid. This checks the length, format and check
     digit."""
     number = compact(number)
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is valid. This checks the length, format and check
     digit."""
     try:

--- a/stdnum/eu/nace.py
+++ b/stdnum/eu/nace.py
@@ -51,20 +51,20 @@ InvalidLength: ...
 >>> format('6201')
 '62.01'
 """  # noqa: E501
+from __future__ import annotations
 
-import warnings
-
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '.').strip()
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Lookup information about the specified NACE. This returns a dict."""
     number = compact(number)
     from stdnum import numdb
@@ -76,20 +76,18 @@ def info(number):
     return info
 
 
-def get_label(number):
+def get_label(number: str) -> str:
     """Lookup the category label for the number."""
     return info(number)['label']
 
 
-def label(number):  # pragma: no cover (deprecated function)
+@t.deprecated('label() has been renamed to get_label()')
+def label(number: str) -> str:  # pragma: no cover (deprecated function)
     """DEPRECATED: use `get_label()` instead."""  # noqa: D40
-    warnings.warn(
-        'label() has been to get_label()',
-        DeprecationWarning, stacklevel=2)
     return get_label(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid NACE. This checks the format and
     searches the registry to see if it exists."""
     number = compact(number)
@@ -105,7 +103,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid NACE. This checks the format and
     searches the registry to see if it exists."""
     try:
@@ -114,6 +112,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return '.'.join((number[:2], number[2:])).strip('.')

--- a/stdnum/eu/oss.py
+++ b/stdnum/eu/oss.py
@@ -49,7 +49,7 @@ More information:
 >>> validate('EU 372022452')
 'EU372022452'
 """
-
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -88,12 +88,12 @@ ISO_3166_1_MEMBER_STATES = (
 """The collection of member state codes (for MSI) that may make up a VAT number."""
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Compact European VAT Number"""
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Validate European VAT Number"""
     number = compact(number)
     if number.startswith('EU'):
@@ -111,7 +111,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number. This performs the
     country-specific check for the number."""
     try:

--- a/stdnum/eu/vat.py
+++ b/stdnum/eu/vat.py
@@ -38,7 +38,9 @@ that country.
 >>> guess_country('00449544B01')
 ['nl']
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.eu import oss
 from stdnum.exceptions import *
 from stdnum.util import clean, get_cc_module, get_soap_client
@@ -59,7 +61,7 @@ vies_wsdl = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl'
 """The WSDL URL of the VAT Information Exchange System (VIES)."""
 
 
-def _get_cc_module(cc):
+def _get_cc_module(cc: str) -> t.NumberValidationModule | None:
     """Get the VAT number module based on the country code."""
     # Greece uses a "wrong" country code
     cc = cc.lower()
@@ -68,7 +70,7 @@ def _get_cc_module(cc):
     if cc == 'el':
         cc = 'gr'
     if cc not in MEMBER_STATES:
-        return
+        return None
     if cc == 'xi':
         cc = 'gb'
     if cc not in _country_modules:
@@ -76,7 +78,7 @@ def _get_cc_module(cc):
     return _country_modules[cc]
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, '').upper().strip()
@@ -90,7 +92,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This performs the
     country-specific check for the number."""
     number = clean(number, '').upper().strip()
@@ -104,7 +106,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number. This performs the
     country-specific check for the number."""
     try:
@@ -113,17 +115,17 @@ def is_valid(number):
         return False
 
 
-def guess_country(number):
+def guess_country(number: str) -> list[str]:
     """Guess the country code based on the number. This checks the number
     against each of the validation routines and returns the list of countries
     for which it is valid. This returns lower case codes and returns gr (not
     el) for Greece."""
     return [cc
             for cc in MEMBER_STATES
-            if _get_cc_module(cc).is_valid(number)]
+            if _get_cc_module(cc).is_valid(number)]  # type: ignore[union-attr]
 
 
-def check_vies(number, timeout=30, verify=True):  # pragma: no cover (not part of normal test suite)
+def check_vies(number, timeout=30, verify=True):  # type: ignore # pragma: no cover (not part of normal test suite)
     """Use the EU VIES service to validate the provided number.
 
     Query the online European Commission VAT Information Exchange System
@@ -145,7 +147,7 @@ def check_vies(number, timeout=30, verify=True):  # pragma: no cover (not part o
     return client.checkVat(number[:2], number[2:])
 
 
-def check_vies_approx(number, requester, timeout=30, verify=True):  # pragma: no cover
+def check_vies_approx(number, requester, timeout=30, verify=True):  # type: ignore # pragma: no cover
     """Use the EU VIES service to validate the provided number.
 
     Query the online European Commission VAT Information Exchange System

--- a/stdnum/exceptions.py
+++ b/stdnum/exceptions.py
@@ -23,6 +23,7 @@
 The validation functions of stdnum should raise one of the below exceptions
 when validation of the number fails.
 """
+from __future__ import annotations
 
 
 __all__ = ['ValidationError', 'InvalidFormat', 'InvalidChecksum',
@@ -35,7 +36,7 @@ class ValidationError(ValueError):
     This exception should normally not be raised, only subclasses of this
     exception."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the exception message."""
         return ''.join(self.args[:1]) or getattr(self, 'message', '')
 

--- a/stdnum/fi/__init__.py
+++ b/stdnum/fi/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Finnish numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.fi import alv as vat  # noqa: F401

--- a/stdnum/fi/alv.py
+++ b/stdnum/fi/alv.py
@@ -29,12 +29,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -43,13 +44,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (7, 9, 10, 5, 8, 4, 2, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -62,7 +63,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/fi/associationid.py
+++ b/stdnum/fi/associationid.py
@@ -41,6 +41,7 @@ InvalidFormat: The number has an invalid format.
 >>> format('1234')
 '1.234'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -53,13 +54,13 @@ _lownumbers = set((
     83, 84, 85, 89, 92))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -._+').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Finnish association register number.
     This checks the length and format."""
     number = compact(number)
@@ -72,7 +73,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid association register number."""
     try:
         return bool(validate(number))
@@ -80,7 +81,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     if len(number) <= 3:

--- a/stdnum/fi/hetu.py
+++ b/stdnum/fi/hetu.py
@@ -40,6 +40,7 @@ InvalidComponent: ...
 >>> compact('131052a308t')
 '131052A308T'
 """
+from __future__ import annotations
 
 import datetime
 import re
@@ -62,17 +63,17 @@ _hetu_re = re.compile(r'^(?P<day>[0123]\d)(?P<month>[01]\d)(?P<year>\d\d)'
                       r'(?P<control>[0-9ABCDEFHJKLMNPRSTUVWXY])$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the HETU to the minimal representation. This strips
     surrounding whitespace and converts it to upper case."""
     return clean(number, '').upper().strip()
 
 
-def _calc_checksum(number):
+def _calc_checksum(number: str) -> str:
     return '0123456789ABCDEFHJKLMNPRSTUVWXY'[int(number) % 31]
 
 
-def validate(number, allow_temporary=False):
+def validate(number: str, allow_temporary: bool = False) -> str:
     """Check if the number is a valid HETU. It checks the format, whether a
     valid date is given and whether the check digit is correct. Allows
     temporary identifier range for individuals (900-999) if allow_temporary
@@ -104,7 +105,7 @@ def validate(number, allow_temporary=False):
     return number
 
 
-def is_valid(number, allow_temporary=False):
+def is_valid(number: str, allow_temporary: bool = False) -> bool:
     """Check if the number is a valid HETU."""
     try:
         return bool(validate(number, allow_temporary))

--- a/stdnum/fi/veronumero.py
+++ b/stdnum/fi/veronumero.py
@@ -42,18 +42,19 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the Veronumero to the minimal representation. This strips
     surrounding whitespace and removes separators."""
     return clean(number, ' ').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid tax number. This checks the length and
     formatting."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid tax number."""
     try:
         return bool(validate(number))

--- a/stdnum/fi/ytunnus.py
+++ b/stdnum/fi/ytunnus.py
@@ -32,24 +32,25 @@ InvalidChecksum: ...
 >>> format('2077474-0')
 '2077474-0'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.fi import alv
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return alv.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid business identifier. This checks the
     length, formatting and check digit."""
     return alv.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid business identifier."""
     try:
         return bool(validate(number))
@@ -57,7 +58,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:7] + '-' + number[7:]

--- a/stdnum/figi.py
+++ b/stdnum/figi.py
@@ -36,18 +36,19 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digits for the number."""
     # we use the full alphabet for the check digit calculation
     alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -58,7 +59,7 @@ def calc_check_digit(number):
     return str((10 - sum(int(n) for n in number)) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid FIGI."""
     number = compact(number)
     if not all(x in '0123456789BCDFGHJKLMNPQRSTVWXYZ' for x in number):
@@ -76,7 +77,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid FIGI."""
     try:
         return bool(validate(number))

--- a/stdnum/fo/__init__.py
+++ b/stdnum/fo/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Faroe Islands numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.fo import vn as vat  # noqa: F401

--- a/stdnum/fo/vn.py
+++ b/stdnum/fo/vn.py
@@ -41,12 +41,13 @@ InvalidFormat: ...
 >>> format('602 590')
 '602590'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -58,7 +59,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Faroe Islands V-number number.
 
     This checks the length and formatting.
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Faroe Islands V-number number."""
     try:
         return bool(validate(number))
@@ -79,6 +80,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/fr/__init__.py
+++ b/stdnum/fr/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of French numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.fr import tva as vat  # noqa: F401

--- a/stdnum/fr/nif.py
+++ b/stdnum/fr/nif.py
@@ -47,23 +47,24 @@ InvalidComponent: ...
 >>> format('3023217600053')
 '30 23 217 600 053'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     return '%03d' % (int(number[:10]) % 511)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid NIF."""
     number = compact(number)
     if not isdigits(number):
@@ -77,7 +78,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid NIF."""
     try:
         return bool(validate(number))
@@ -85,7 +86,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:2], number[2:4], number[4:7],

--- a/stdnum/fr/nir.py
+++ b/stdnum/fr/nir.py
@@ -60,18 +60,19 @@ InvalidLength: ...
 >>> format('295109912611193')
 '2 95 10 99 126 111 93'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip().upper()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     department = number[5:7]
     if department == '2A':
@@ -81,7 +82,7 @@ def calc_check_digits(number):
     return '%02d' % (97 - (int(number[:13]) % 97))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length
     and check digits."""
     number = compact(number)
@@ -96,7 +97,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid."""
     try:
         return bool(validate(number))
@@ -104,7 +105,7 @@ def is_valid(number):
         return False
 
 
-def format(number, separator=' '):
+def format(number: str, separator: str = ' ') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return separator.join((

--- a/stdnum/fr/siren.py
+++ b/stdnum/fr/siren.py
@@ -35,6 +35,7 @@ InvalidChecksum: ...
 >>> to_tva('443 121 975')
 '46 443 121 975'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
@@ -47,13 +48,13 @@ from stdnum.util import clean, isdigits
 # https://avis-situation-sirene.insee.fr/
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid SIREN. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid SIREN."""
     try:
         return bool(validate(number))
@@ -73,7 +74,7 @@ def is_valid(number):
         return False
 
 
-def to_tva(number):
+def to_tva(number: str) -> str:
     """Return a TVA that prepends the two extra check digits to the SIREN."""
     # note that this always returns numeric check digits
     # it is unclean when the alphabetic ones are used

--- a/stdnum/fr/siret.py
+++ b/stdnum/fr/siret.py
@@ -46,6 +46,7 @@ InvalidChecksum: ...
 >>> format('73282932000074')
 '732 829 320 00074'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
@@ -53,13 +54,13 @@ from stdnum.fr import siren
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid SIRET. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -78,7 +79,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid SIRET."""
     try:
         return bool(validate(number))
@@ -86,7 +87,7 @@ def is_valid(number):
         return False
 
 
-def to_siren(number):
+def to_siren(number: str) -> str:
     """Convert the SIRET number to a SIREN number.
 
     The SIREN number is the 9 first digits of the SIRET number.
@@ -101,7 +102,7 @@ def to_siren(number):
     return ''.join(_siren)
 
 
-def to_tva(number):
+def to_tva(number: str) -> str:
     """Convert the SIRET number to a TVA number.
 
     The TVA number is built from the SIREN number, prepended by two extra
@@ -110,7 +111,7 @@ def to_tva(number):
     return siren.to_tva(to_siren(number))
 
 
-def format(number, separator=' '):
+def format(number: str, separator: str = ' ') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return separator.join((number[0:3], number[3:6], number[6:9], number[9:]))

--- a/stdnum/fr/tva.py
+++ b/stdnum/fr/tva.py
@@ -42,6 +42,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.fr import siren
@@ -52,7 +53,7 @@ from stdnum.util import clean, isdigits
 _alphabet = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -61,7 +62,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -93,7 +94,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/gb/nhs.py
+++ b/stdnum/gb/nhs.py
@@ -40,24 +40,25 @@ InvalidChecksum: ...
 >>> format('9434765870')
 '943 476 5870'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. The checksum is only used for the 9 digits
     of the number and the result can either be 0 or 42."""
     return sum(i * int(n) for i, n in enumerate(reversed(number), 1)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is valid. This checks the length and check
     digit."""
     number = compact(number)
@@ -70,7 +71,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is valid."""
     try:
         return bool(validate(number))
@@ -78,7 +79,7 @@ def is_valid(number):
         return False
 
 
-def format(number, separator=' '):
+def format(number: str, separator: str = ' ') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return separator.join((number[0:3], number[3:6], number[6:]))

--- a/stdnum/gb/sedol.py
+++ b/stdnum/gb/sedol.py
@@ -32,6 +32,7 @@ InvalidChecksum: ...
 >>> to_isin('B15KXQ8')
 'GB00B15KXQ89'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -41,20 +42,20 @@ from stdnum.util import clean, isdigits
 _alphabet = '0123456789 BCD FGH JKLMN PQRST VWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digits for the number."""
     weights = (1, 3, 1, 7, 3, 9)
     s = sum(w * _alphabet.index(n) for w, n in zip(weights, number))
     return str((10 - s) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is valid. This checks the length and check
     digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is valid."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def to_isin(number):
+def to_isin(number: str) -> str:
     """Convert the number to an ISIN."""
     from stdnum import isin
     return isin.from_natid('GB', number)

--- a/stdnum/gb/upn.py
+++ b/stdnum/gb/upn.py
@@ -47,6 +47,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -72,20 +73,20 @@ _la_numbers = set((
     919, 921, 925, 926, 928, 929, 931, 933, 935, 936, 937, 938))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     check = sum(i * _alphabet.index(n)
                 for i, n in enumerate(number[-12:], 2)) % 23
     return _alphabet[check]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid UPN. This checks length, formatting and
     check digits."""
     number = compact(number)
@@ -100,7 +101,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid UPN."""
     try:
         return bool(validate(number))

--- a/stdnum/gb/utr.py
+++ b/stdnum/gb/utr.py
@@ -34,25 +34,26 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ..
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').upper().strip().lstrip('K')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number. The passed number should not
     have the check digit (the first one) included."""
     weights = (6, 7, 8, 9, 10, 5, 4, 3, 2)
     return '21987654321'[sum(int(n) * w for n, w in zip(number, weights)) % 11]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid UTR."""
     number = compact(number)
     if not isdigits(number):
@@ -64,7 +65,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid UTR."""
     try:
         return bool(validate(number))

--- a/stdnum/gb/vat.py
+++ b/stdnum/gb/vat.py
@@ -34,12 +34,13 @@ InvalidChecksum: ...
 >>> format('980780684')
 '980 7806 84'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -48,14 +49,14 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. The checksum is only used for the 9 digits
     of the number and the result can either be 0 or 42."""
     weights = (8, 7, 6, 5, 4, 3, 2, 10, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 97
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -100,7 +101,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))
@@ -108,7 +109,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     if len(number) == 5:

--- a/stdnum/gh/__init__.py
+++ b/stdnum/gh/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Ghana numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.gh import tin as vat  # noqa: F401

--- a/stdnum/gh/tin.py
+++ b/stdnum/gh/tin.py
@@ -46,6 +46,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """  # noqa: E501
+from __future__ import annotations
 
 import re
 
@@ -56,7 +57,7 @@ from stdnum.util import clean
 _gh_tin_re = re.compile(r'^[PCGQV]{1}00[A-Z0-9]{8}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -65,13 +66,13 @@ def compact(number):
     return clean(number, ' ').upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the TIN."""
     check = sum((i + 1) * int(n) for i, n in enumerate(number[1:10])) % 11
     return 'X' if check == 10 else str(check)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Ghana TIN."""
     number = compact(number)
     if len(number) != 11:
@@ -83,7 +84,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Ghana TIN."""
     try:
         return bool(validate(number))

--- a/stdnum/gn/__init__.py
+++ b/stdnum/gn/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Guinea numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.gn import nifp as vat  # noqa: F401

--- a/stdnum/gn/nifp.py
+++ b/stdnum/gn/nifp.py
@@ -43,13 +43,14 @@ InvalidChecksum: ...
 >>> format('693770885')
 '693-770-885'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -58,7 +59,7 @@ def compact(number):
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Guinea NIFp number.
 
     This checks the length, formatting and check digit.
@@ -72,7 +73,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Guinea NIFp number."""
     try:
         return bool(validate(number))
@@ -80,7 +81,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:3], number[3:-3], number[-3:]])

--- a/stdnum/gr/amka.py
+++ b/stdnum/gr/amka.py
@@ -40,21 +40,23 @@ datetime.date(1930, 1, 1)
 >>> get_gender('01013099997')
 'M'
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the date of birth.
     Since only two digits are used for the year, the century may be
     incorrect."""
@@ -71,7 +73,7 @@ def get_birth_date(number):
             raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the gender (M/F) from the person's AMKA."""
     number = compact(number)
     if int(number[9]) % 2:
@@ -80,7 +82,7 @@ def get_gender(number):
         return 'F'
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid AMKA. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -93,7 +95,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid AMKA."""
     try:
         return bool(validate(number))

--- a/stdnum/gr/vat.py
+++ b/stdnum/gr/vat.py
@@ -31,12 +31,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -./:').upper().strip()
@@ -47,7 +48,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     checksum = 0
@@ -56,7 +57,7 @@ def calc_check_digit(number):
     return str(checksum * 2 % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -69,7 +70,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/grid.py
+++ b/stdnum/grid.py
@@ -36,12 +36,13 @@ InvalidChecksum: ...
 >>> format('A12425GABC1234002M')
 'A1-2425G-ABC1234002-M'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the GRid to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').strip().upper()
@@ -50,7 +51,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid GRid."""
     from stdnum.iso7064 import mod_37_36
     number = compact(number)
@@ -59,7 +60,7 @@ def validate(number):
     return mod_37_36.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid GRid."""
     try:
         return bool(validate(number))
@@ -67,8 +68,8 @@ def is_valid(number):
         return False
 
 
-def format(number, separator='-'):
+def format(number: str, separator: str = '-') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
-    number = (number[0:2], number[2:7], number[7:17], number[17:])
-    return separator.join(x for x in number if x)
+    parts = (number[0:2], number[2:7], number[7:17], number[17:])
+    return separator.join(x for x in parts if x)

--- a/stdnum/gt/__init__.py
+++ b/stdnum/gt/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Guatemalan numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.gt import nit as vat  # noqa: F401

--- a/stdnum/gt/nit.py
+++ b/stdnum/gt/nit.py
@@ -47,25 +47,26 @@ InvalidLength: ...
 >>> format('39525503')
 '3952550-3'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip().lstrip('0')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     c = -sum(i * int(n) for i, n in enumerate(reversed(number), 2)) % 11
     return 'K' if c == 10 else str(c)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Guatemala NIT number.
 
     This checks the length, formatting and check digit.
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Guatemala NIT number."""
     try:
         return bool(validate(number))
@@ -90,7 +91,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:-1], number[-1]])

--- a/stdnum/hr/__init__.py
+++ b/stdnum/hr/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Croatian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.hr import oib as vat  # noqa: F401

--- a/stdnum/hr/oib.py
+++ b/stdnum/hr/oib.py
@@ -31,13 +31,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_11_10
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -46,7 +47,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid OIB number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -58,7 +59,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid OIB number."""
     try:
         return bool(validate(number))

--- a/stdnum/hu/__init__.py
+++ b/stdnum/hu/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Hungarian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.hu import anum as vat  # noqa: F401

--- a/stdnum/hu/anum.py
+++ b/stdnum/hu/anum.py
@@ -30,12 +30,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -44,13 +45,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. Valid numbers should have a checksum of 0."""
     weights = (9, 7, 3, 1, 9, 7, 3, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 10
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/iban.py
+++ b/stdnum/iban.py
@@ -43,9 +43,11 @@ More information:
 >>> calc_check_digits('BExx435411161155')
 '31'
 """
+from __future__ import annotations
 
 import re
 
+from stdnum import _typing as t
 from stdnum import numdb
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
@@ -62,23 +64,23 @@ _struct_re = re.compile(r'([1-9][0-9]*)!([nac])')
 _country_modules = {}
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the iban number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip().upper()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits that should be put in the number to make
     it valid. Check digits in the supplied number are ignored."""
     number = compact(number)
     return mod_97_10.calc_check_digits(number[4:] + number[:2])
 
 
-def _struct_to_re(structure):
+def _struct_to_re(structure: str) -> re.Pattern[str]:
     """Convert an IBAN structure to a regular expression that can be used
     to validate the number."""
-    def conv(match):
+    def conv(match: re.Match[str]) -> str:
         chars = {
             'n': '[0-9]',
             'a': '[A-Z]',
@@ -88,7 +90,7 @@ def _struct_to_re(structure):
     return re.compile('^%s$' % _struct_re.sub(conv, structure))
 
 
-def _get_cc_module(cc):
+def _get_cc_module(cc: str) -> t.NumberValidationModule | None:
     """Get the IBAN module based on the country code."""
     cc = cc.lower()
     if cc not in _country_modules:
@@ -96,7 +98,7 @@ def _get_cc_module(cc):
     return _country_modules[cc]
 
 
-def validate(number, check_country=True):
+def validate(number: str, check_country: bool = True) -> str:
     """Check if the number provided is a valid IBAN. The country-specific
     check can be disabled with the check_country argument."""
     number = compact(number)
@@ -119,7 +121,7 @@ def validate(number, check_country=True):
     return number
 
 
-def is_valid(number, check_country=True):
+def is_valid(number: str, check_country: bool = True) -> bool:
     """Check if the number provided is a valid IBAN."""
     try:
         return bool(validate(number, check_country=check_country))
@@ -127,7 +129,7 @@ def is_valid(number, check_country=True):
         return False
 
 
-def format(number, separator=' '):
+def format(number: str, separator: str = ' ') -> str:
     """Reformat the passed number to the space-separated format."""
     number = compact(number)
     return separator.join(number[i:i + 4] for i in range(0, len(number), 4))

--- a/stdnum/id/__init__.py
+++ b/stdnum/id/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Indonesian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.id import npwp as vat  # noqa: F401

--- a/stdnum/id/nik.py
+++ b/stdnum/id/nik.py
@@ -54,6 +54,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import datetime
 
@@ -61,7 +62,7 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes
@@ -70,7 +71,7 @@ def compact(number):
     return clean(number, ' -.').strip()
 
 
-def get_birth_date(number, minyear=1920):
+def get_birth_date(number: str, minyear: int = 1920) -> datetime.date:
     """Get the birth date from the person's NIK.
 
     Note that the number only encodes the last two digits of the year so
@@ -90,7 +91,7 @@ def get_birth_date(number, minyear=1920):
         raise InvalidComponent()
 
 
-def _check_registration_place(number):
+def _check_registration_place(number: str) -> dict[str, str]:
     """Use the number to look up the place of registration of the person."""
     from stdnum import numdb
     results = numdb.get('id/loc').info(number[:4])[0][1]
@@ -99,7 +100,7 @@ def _check_registration_place(number):
     return results
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Indonesian NIK."""
     number = compact(number)
     if not isdigits(number):
@@ -111,7 +112,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Indonesian NIK."""
     try:
         return bool(validate(number))

--- a/stdnum/id/npwp.py
+++ b/stdnum/id/npwp.py
@@ -51,6 +51,7 @@ InvalidLength: ...
 >>> format('013000666091000')
 '01.300.066.6-091.000'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
@@ -58,7 +59,7 @@ from stdnum.id import nik
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes
@@ -67,7 +68,7 @@ def compact(number):
     return clean(number, ' -.').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Indonesia NPWP number."""
     number = compact(number)
     if not isdigits(number):
@@ -86,7 +87,7 @@ def validate(number):
     raise InvalidLength()
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Indonesia NPWP number."""
     try:
         return bool(validate(number))
@@ -94,7 +95,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '%s.%s.%s.%s-%s.%s' % (

--- a/stdnum/ie/pps.py
+++ b/stdnum/ie/pps.py
@@ -50,6 +50,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -62,13 +63,13 @@ pps_re = re.compile(r'^\d{7}[A-W][ABHWTX]?$')
 """Regular expression used to check syntax of PPS numbers."""
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid PPS number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -85,7 +86,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid PPS number. This checks the
     length, formatting and check digit."""
     try:

--- a/stdnum/ie/vat.py
+++ b/stdnum/ie/vat.py
@@ -40,12 +40,13 @@ InvalidFormat: ...
 >>> convert('1F23456T')
 '0234561T'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -57,7 +58,7 @@ def compact(number):
 _alphabet = 'WABCDEFGHIJKLMNOPQRSTUV'
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     number = compact(number).zfill(7)
@@ -66,7 +67,7 @@ def calc_check_digit(number):
         9 * _alphabet.index(number[7:])) % 23]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -89,7 +90,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length, formatting and check digit."""
     try:
@@ -98,7 +99,7 @@ def is_valid(number):
         return False
 
 
-def convert(number):
+def convert(number: str) -> str:
     """Convert an "old" style 8-digit VAT number where the second character
     is a letter to the new 8-digit format where only the last digit is a
     character."""

--- a/stdnum/il/__init__.py
+++ b/stdnum/il/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Israeli numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.il import hp as vat  # noqa: F401

--- a/stdnum/il/hp.py
+++ b/stdnum/il/hp.py
@@ -47,19 +47,20 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ID. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -73,7 +74,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ID. This checks the length,
     formatting and check digit."""
     try:
@@ -82,6 +83,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/il/idnr.py
+++ b/stdnum/il/idnr.py
@@ -42,19 +42,20 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().zfill(9)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ID. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ID. This checks the length,
     formatting and check digit."""
     try:
@@ -75,7 +76,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:-1] + '-' + number[-1:]

--- a/stdnum/imei.py
+++ b/stdnum/imei.py
@@ -45,19 +45,20 @@ InvalidChecksum: ...
 >>> split('35686800-004141')
 ('35686800', '004141', '')
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the IMEI number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid IMEI (or IMEISV) number."""
     number = compact(number)
     if not isdigits(number):
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def imei_type(number):
+def imei_type(number: str) -> str | None:
     """Check the passed number and return 'IMEI', 'IMEISV' or None (for
     invalid) for checking the type of number passed."""
     try:
@@ -84,7 +85,7 @@ def imei_type(number):
         return 'IMEISV'
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid IMEI (or IMEISV) number."""
     try:
         return bool(validate(number))
@@ -92,7 +93,7 @@ def is_valid(number):
         return False
 
 
-def split(number):
+def split(number: str) -> tuple[str, str, str]:
     """Split the number into a Type Allocation Code (TAC), serial number
     and either the checksum (for IMEI) or the software version number (for
     IMEISV)."""
@@ -100,10 +101,10 @@ def split(number):
     return (number[:8], number[8:14], number[14:])
 
 
-def format(number, separator='-', add_check_digit=False):
+def format(number: str, separator: str = '-', add_check_digit: bool = False) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     if len(number) == 14 and add_check_digit:
         number += luhn.calc_check_digit(number)
-    number = (number[:2], number[2:8], number[8:14], number[14:])
-    return separator.join(x for x in number if x)
+    parts = (number[:2], number[2:8], number[8:14], number[14:])
+    return separator.join(x for x in parts if x)

--- a/stdnum/imo.py
+++ b/stdnum/imo.py
@@ -39,12 +39,13 @@ InvalidChecksum: ...
 >>> format('8814275')
 'IMO 8814275'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -53,12 +54,12 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digits for the number."""
     return str(sum(int(n) * (7 - i) for i, n in enumerate(number[:6])) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:
@@ -80,6 +81,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return 'IMO ' + compact(number)

--- a/stdnum/imsi.py
+++ b/stdnum/imsi.py
@@ -38,18 +38,20 @@ InvalidComponent: ...
 >>> info('460001234567890')['country']
 'China'
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the IMSI number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def split(number):
+def split(number: str) -> tuple[str, ...]:
     """Split the specified IMSI into a Mobile Country Code (MCC), a Mobile
     Network Code (MNC), a Mobile Station Identification Number (MSIN)."""
     # clean up number
@@ -59,7 +61,7 @@ def split(number):
     return tuple(numdb.get('imsi').split(number))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid IMSI."""
     number = compact(number)
     if not isdigits(number):
@@ -71,7 +73,7 @@ def validate(number):
     return number
 
 
-def info(number):
+def info(number: str) -> t.IMSIInfo:
     """Return a dictionary of data about the supplied number."""
     # clean up number
     number = compact(number)
@@ -85,10 +87,10 @@ def info(number):
     info.update(mnc_info[1])
     info['msin'] = msin_info[0]
     info.update(msin_info[1])
-    return info
+    return t.cast('t.IMSIInfo', info)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid IMSI."""
     try:
         return bool(validate(number))

--- a/stdnum/in_/__init__.py
+++ b/stdnum/in_/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Indian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.in_ import gstin as vat  # noqa: F401

--- a/stdnum/in_/aadhaar.py
+++ b/stdnum/in_/aadhaar.py
@@ -57,6 +57,7 @@ InvalidFormat: ...
 >>> mask('234123412346')
 'XXXX XXXX 2346'
 """
+from __future__ import annotations
 
 import re
 
@@ -69,13 +70,13 @@ aadhaar_re = re.compile(r'^[2-9][0-9]{11}$')
 """Regular expression used to check syntax of Aadhaar numbers."""
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
     number = compact(number)
@@ -89,7 +90,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Aadhaar number. This checks
     the length, formatting and check digit."""
     try:
@@ -98,13 +99,13 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:4], number[4:8], number[8:]))
 
 
-def mask(number):
+def mask(number: str) -> str:
     """Masks the first 8 digits as per Ministry of Electronics and
     Information Technology (MeitY) guidelines."""
     number = compact(number)

--- a/stdnum/in_/epic.py
+++ b/stdnum/in_/epic.py
@@ -51,6 +51,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -62,13 +63,13 @@ from stdnum.util import clean
 _EPIC_RE = re.compile(r'^[A-Z]{3}[0-9]{7}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid EPIC number. This checks the
     length, formatting and checksum."""
     number = compact(number)
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid EPIC number. This checks the
     length, formatting and checksum."""
     try:

--- a/stdnum/in_/gstin.py
+++ b/stdnum/in_/gstin.py
@@ -58,9 +58,11 @@ InvalidChecksum: ...
 >>> info('27AAPFU0939F1ZV')['state']
 'Maharashtra'
 """
+from __future__ import annotations
 
 import re
 
+from stdnum import _typing as t
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.in_ import pan
@@ -112,13 +114,13 @@ _STATE_CODES = {
 }
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid GSTIN. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -133,7 +135,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid GSTIN. This checks the length,
     formatting and check digit."""
     try:
@@ -142,13 +144,13 @@ def is_valid(number):
         return False
 
 
-def to_pan(number):
+def to_pan(number: str) -> str:
     """Convert the number to a PAN."""
     number = compact(number)
     return number[2:12]
 
 
-def info(number):
+def info(number: str) -> t.GSTINInfo:
     """Provide information that can be decoded locally from GSTIN (without
     API)."""
     number = validate(number)

--- a/stdnum/in_/pan.py
+++ b/stdnum/in_/pan.py
@@ -58,9 +58,11 @@ InvalidComponent: ...
 >>> info('AAPPV8261K')['holder_type']
 'Individual'
 """
+from __future__ import annotations
 
 import re
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean
 
@@ -83,13 +85,13 @@ _pan_holder_types = {
 # Type 'K' may have been discontinued, not listed on Income Text Dept website.
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid PAN. This checks the length
     and formatting."""
     number = compact(number)
@@ -103,7 +105,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid PAN. This checks the length
     and formatting."""
     try:
@@ -112,20 +114,22 @@ def is_valid(number):
         return False
 
 
-def info(number):
+def info(number: str) -> t.PANInfo:
     """Provide information that can be decoded from the PAN."""
     number = compact(number)
     holder_type = _pan_holder_types.get(number[3])
     if not holder_type:
         raise InvalidComponent()
-    return {
+    # we exclude the backwards compatibility key from the typed dict
+    # so people that use type hints can migrate to the new key
+    return {  # type: ignore[typeddict-unknown-key]
         'holder_type': holder_type,
         'card_holder_type': holder_type,  # for backwards compatibility
         'initial': number[4],
     }
 
 
-def mask(number):
+def mask(number: str) -> str:
     """Mask the PAN as per Central Board of Direct Taxes (CBDT) masking
     standard."""
     number = compact(number)

--- a/stdnum/in_/vid.py
+++ b/stdnum/in_/vid.py
@@ -55,6 +55,7 @@ InvalidFormat: ...
 >>> mask('2341234123412342')
 'XXXX XXXX  XXXX 2342'
 """
+from __future__ import annotations
 
 import re
 
@@ -67,13 +68,13 @@ _vid_re = re.compile(r'^[2-9][0-9]{15}$')
 """Regular expression used to check syntax of VID numbers."""
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VID number. This checks
     the length, formatting and check digit."""
     number = compact(number)
@@ -87,7 +88,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VID number. This checks
     the length, formatting and check digit."""
     try:
@@ -96,13 +97,13 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:4], number[4:8], number[8:12], number[12:]))
 
 
-def mask(number):
+def mask(number: str) -> str:
     """Masks the first 8 digits as per Ministry of Electronics and
     Information Technology (MeitY) guidelines."""
     number = compact(number)

--- a/stdnum/is_/__init__.py
+++ b/stdnum/is_/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Icelandic numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.is_ import kennitala as personalid  # noqa: F401

--- a/stdnum/is_/kennitala.py
+++ b/stdnum/is_/kennitala.py
@@ -39,6 +39,7 @@ InvalidComponent: ...
 >>> format('1201743399')
 '120174-3399'
 """
+from __future__ import annotations
 
 import datetime
 import re
@@ -58,20 +59,20 @@ _kennitala_re = re.compile(
     r'(?P<century>[09])$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the kennitala to the minimal representation. This
     strips surrounding whitespace and separation dash, and converts it
     to upper case."""
     return clean(number, '-').upper().strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (3, 2, 7, 6, 5, 4, 3, 2, 1, 0)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid kennitala. It checks the
     format, whether a valid date is given and whether the check digit is
     correct."""
@@ -100,7 +101,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid HETU. It checks the format,
     whether a valid date is given and whether the check digit is correct."""
     try:
@@ -109,7 +110,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:6] + '-' + number[6:]

--- a/stdnum/is_/vsk.py
+++ b/stdnum/is_/vsk.py
@@ -29,12 +29,13 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -43,7 +44,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid VAT number. This checks the
     length and formatting."""
     number = compact(number)
@@ -54,7 +55,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid VAT number. This checks the
     length and formatting."""
     try:

--- a/stdnum/isan.py
+++ b/stdnum/isan.py
@@ -46,13 +46,14 @@ InvalidChecksum: ...
 >>> to_xml('1881-66C7-3420-6541-Y-9F3A-0245-O')
 '<ISAN root="1881-66C7-3420" episode="6541" version="9F3A-0245" />'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_37_36
 from stdnum.util import clean
 
 
-def split(number):
+def split(number: str) -> tuple[str, str, str, str, str]:
     """Split the number into a root, an episode or part, a check digit a
     version and another check digit. If any of the parts are missing an empty
     string is returned."""
@@ -65,17 +66,17 @@ def split(number):
         return number[0:12], number[12:16], number[16:], '', ''
 
 
-def compact(number, strip_check_digits=True):
+def compact(number: str, strip_check_digits: bool = True) -> str:
     """Convert the ISAN to the minimal representation. This strips the number
     of any valid separators and removes surrounding whitespace. The check
     digits are removed by default."""
-    number = list(split(number))
+    digits = list(split(number))
     if strip_check_digits:
-        number[2] = number[4] = ''
-    return ''.join(number)
+        digits[2] = digits[4] = ''
+    return ''.join(digits)
 
 
-def validate(number, strip_check_digits=False, add_check_digits=False):
+def validate(number: str, strip_check_digits: bool = False, add_check_digits: bool = False) -> str:
     """Check if the number provided is a valid ISAN. If check digits are
     present in the number they are validated. If strip_check_digits is True
     any existing check digits will be removed (after checking). If
@@ -106,7 +107,7 @@ def validate(number, strip_check_digits=False, add_check_digits=False):
     return root + episode + check1 + version + check2
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISAN. If check digits are
     present in the number they are validated."""
     try:
@@ -115,7 +116,12 @@ def is_valid(number):
         return False
 
 
-def format(number, separator='-', strip_check_digits=False, add_check_digits=True):
+def format(
+    number: str,
+    separator: str = '-',
+    strip_check_digits: bool = False,
+    add_check_digits: bool = True,
+) -> str:
     """Reformat the number to the standard presentation format. If
     add_check_digits is True the check digit will be added if they are not
     present yet. If both strip_check_digits and add_check_digits are True the
@@ -127,30 +133,30 @@ def format(number, separator='-', strip_check_digits=False, add_check_digits=Tru
         check1 = mod_37_36.calc_check_digit(root + episode)
     if add_check_digits and not check2 and version:
         check2 = mod_37_36.calc_check_digit(root + episode + version)
-    number = [root[i:i + 4] for i in range(0, 12, 4)] + [episode]
+    parts = [root[i:i + 4] for i in range(0, 12, 4)] + [episode]
     if check1:
-        number.append(check1)
+        parts.append(check1)
     if version:
-        number.extend((version[0:4], version[4:]))
+        parts.extend((version[0:4], version[4:]))
     if check2:
-        number.append(check2)
-    return separator.join(number)
+        parts.append(check2)
+    return separator.join(parts)
 
 
-def to_binary(number):
+def to_binary(number: str) -> bytes:
     """Convert the number to its binary representation (without the check
     digits)."""
     from binascii import a2b_hex
     return a2b_hex(compact(number, strip_check_digits=True))
 
 
-def to_xml(number):
+def to_xml(number: str) -> str:
     """Return the XML form of the ISAN as a string."""
     number = format(number, strip_check_digits=True, add_check_digits=False)
     return '<ISAN root="%s" episode="%s" version="%s" />' % (
         number[0:14], number[15:19], number[20:])
 
 
-def to_urn(number):
+def to_urn(number: str) -> str:
     """Return the URN representation of the ISAN."""
     return 'URN:ISAN:' + format(number, add_check_digits=True)

--- a/stdnum/isbn.py
+++ b/stdnum/isbn.py
@@ -60,13 +60,14 @@ InvalidChecksum: ...
 >>> to_isbn10('978-1-85798-218-3')
 '1-85798-218-5'
 """
+from __future__ import annotations
 
 from stdnum import ean
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number, convert=False):
+def compact(number: str, convert: bool = False) -> str:
     """Convert the ISBN to the minimal representation. This strips the number
     of any valid ISBN separators and removes surrounding whitespace. If the
     convert parameter is True the number is also converted to ISBN-13
@@ -79,7 +80,7 @@ def compact(number, convert=False):
     return number
 
 
-def _calc_isbn10_check_digit(number):
+def _calc_isbn10_check_digit(number: str) -> str:
     """Calculate the ISBN check digit for 10-digit numbers. The number passed
     should not have the check digit included."""
     check = sum((i + 1) * int(n)
@@ -87,7 +88,7 @@ def _calc_isbn10_check_digit(number):
     return 'X' if check == 10 else str(check)
 
 
-def validate(number, convert=False):
+def validate(number: str, convert: bool = False) -> str:
     """Check if the number provided is a valid ISBN (either a legacy 10-digit
     one or a 13-digit one). This checks the length and the check digit but does
     not check if the group and publisher are valid (use split() for that)."""
@@ -108,7 +109,7 @@ def validate(number, convert=False):
     return number
 
 
-def isbn_type(number):
+def isbn_type(number: str) -> str | None:
     """Check the passed number and return 'ISBN13', 'ISBN10' or None (for
     invalid) for checking the type of number passed."""
     try:
@@ -121,7 +122,7 @@ def isbn_type(number):
         return 'ISBN13'
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISBN (either a legacy 10-digit
     one or a 13-digit one). This checks the length and the check digit but does
     not check if the group and publisher are valid (use split() for that)."""
@@ -131,7 +132,7 @@ def is_valid(number):
         return False
 
 
-def to_isbn13(number):
+def to_isbn13(number: str) -> str:
     """Convert the number to ISBN-13 format."""
     number = number.strip()
     min_number = clean(number, ' -')
@@ -150,7 +151,7 @@ def to_isbn13(number):
         return '978' + number
 
 
-def to_isbn10(number):
+def to_isbn10(number: str) -> str:
     """Convert the number to ISBN-10 format."""
     number = number.strip()
     min_number = compact(number, convert=False)
@@ -172,7 +173,7 @@ def to_isbn10(number):
         return number + digit
 
 
-def split(number, convert=False):
+def split(number: str, convert: bool = False) -> tuple[str, str, str, str, str]:
     """Split the specified ISBN into an EAN.UCC prefix, a group prefix, a
     registrant, an item number and a check digit. If the number is in ISBN-10
     format the returned EAN.UCC prefix is '978'. If the convert parameter is
@@ -195,7 +196,7 @@ def split(number, convert=False):
     return ('' if delprefix else prefix, group, publisher, itemnr, number[-1])
 
 
-def format(number, separator='-', convert=False):
+def format(number: str, separator: str = '-', convert: bool = False) -> str:
     """Reformat the number to the standard presentation format with the
     EAN.UCC prefix (if any), the group prefix, the registrant, the item
     number and the check digit separated (if possible) by the specified

--- a/stdnum/isil.py
+++ b/stdnum/isil.py
@@ -54,6 +54,7 @@ InvalidComponent: ...
 >>> format('it-RM0267')
 'IT-RM0267'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
@@ -64,13 +65,13 @@ _alphabet = set(
     '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-:/')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the ISIL to the minimal representation. This strips
     surrounding whitespace."""
     return clean(number, '').strip()
 
 
-def _is_known_agency(agency):
+def _is_known_agency(agency: str) -> bool:
     """Check whether the specified agency is valid."""
     # look it up in the db
     from stdnum import numdb
@@ -79,7 +80,7 @@ def _is_known_agency(agency):
     return len(results) == 1 and bool(results[0][1])
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ISIL."""
     number = compact(number)
     if not all(x in _alphabet for x in number):
@@ -91,7 +92,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISIL."""
     try:
         return bool(validate(number))
@@ -99,7 +100,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     parts = number.split('-')

--- a/stdnum/isin.py
+++ b/stdnum/isin.py
@@ -40,6 +40,7 @@ InvalidChecksum: ...
 >>> from_natid('gb', 'BYXJL75')
 'GB00BYXJL758'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean
@@ -88,13 +89,13 @@ _country_codes = set(_iso_3116_1_country_codes + [
 _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digits for the number."""
     # convert to numeric first, then double some, then sum individual digits
     number = ''.join(str(_alphabet.index(n)) for n in number)
@@ -103,7 +104,7 @@ def calc_check_digit(number):
     return str((10 - sum(int(n) for n in number)) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     number = compact(number)
@@ -118,7 +119,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length and
     check digit."""
     try:
@@ -127,7 +128,7 @@ def is_valid(number):
         return False
 
 
-def from_natid(country_code, number):
+def from_natid(country_code: str, number: str) -> str:
     """Generate an ISIN from a national security identifier."""
     number = country_code.upper() + compact(number).zfill(9)
     return number + calc_check_digit(number)

--- a/stdnum/ismn.py
+++ b/stdnum/ismn.py
@@ -41,19 +41,20 @@ InvalidChecksum: ...
 >>> to_ismn13('M230671187')
 '9790230671187'
 """
+from __future__ import annotations
 
 from stdnum import ean
 from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the ISMN to the minimal representation. This strips the number
     of any valid ISMN separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ISMN (either a legacy 10-digit
     one or a 13-digit one). This checks the length and the check bit but does
     not check if the publisher is known."""
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def ismn_type(number):
+def ismn_type(number: str) -> str | None:
     """Check the type of ISMN number passed and return 'ISMN13', 'ISMN10'
     or None (for invalid)."""
     try:
@@ -84,7 +85,7 @@ def ismn_type(number):
         return 'ISMN13'
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISMN (either a legacy 10-digit
     one or a 13-digit one). This checks the length and the check bit but does
     not check if the publisher is known."""
@@ -94,10 +95,9 @@ def is_valid(number):
         return False
 
 
-def to_ismn13(number):
+def to_ismn13(number: str) -> str:
     """Convert the number to ISMN13 (EAN) format."""
-    number = number.strip()
-    min_number = compact(number)
+    min_number = validate(number)
     if len(min_number) == 13:
         return number  # nothing to do, already 13 digit format
     # add prefix and strip the M
@@ -115,7 +115,7 @@ _ranges = (
     (6, '700000', '899999'), (7, '9000000', '9999999'))
 
 
-def split(number):
+def split(number: str) -> tuple[str, str, str, str, str]:
     """Split the specified ISMN into a bookland prefix (979), an ISMN
     prefix (0), a publisher element (3 to 7 digits), an item element (2 to
     6 digits) and a check digit."""
@@ -126,9 +126,10 @@ def split(number):
         if low <= number[4:4 + length] <= high:
             return (number[:3], number[3], number[4:4 + length],
                     number[4 + length:-1], number[-1])
+    raise AssertionError('unreachable')  # pragma: no cover
 
 
-def format(number, separator='-'):
+def format(number: str, separator: str = '-') -> str:
     """Reformat the number to the standard presentation format with the
     prefixes, the publisher element, the item element and the check-digit
     separated by the specified separator. The number is converted to the

--- a/stdnum/isni.py
+++ b/stdnum/isni.py
@@ -42,20 +42,20 @@ InvalidLength: ...
 >>> format('000000012281955X')
 '0000 0001 2281 955X'
 """
-
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_11_2
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the ISNI to the minimal representation. This strips the number
     of any valid ISNI separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ISNI. This checks the length and
     whether the check digit is correct."""
     number = compact(number)
@@ -67,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISNI."""
     try:
         return bool(validate(number))
@@ -75,7 +75,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:4], number[4:8], number[8:12], number[12:16]))

--- a/stdnum/iso11649.py
+++ b/stdnum/iso11649.py
@@ -44,19 +44,20 @@ InvalidChecksum: ...
 >>> format('RF18539007547034')
 'RF18 5390 0754 7034'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any invalid separators and removes surrounding whitespace."""
     return clean(number, ' -.,/:').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ISO 11649 structured creditor
     reference number."""
     number = compact(number)
@@ -68,7 +69,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISO 11649 structured creditor
     number. This checks the length, formatting and check digits."""
     try:
@@ -77,7 +78,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Format the number provided for output.
 
     Blocks of 4 characters, the last block can be less than 4 characters. See

--- a/stdnum/iso6346.py
+++ b/stdnum/iso6346.py
@@ -41,6 +41,7 @@ InvalidChecksum: ...
 >>> format('tasu117 000 0')
 'TASU 117000 0'
 """
+from __future__ import annotations
 
 import re
 
@@ -51,13 +52,13 @@ from stdnum.util import clean
 _iso6346_re = re.compile(r'^\w{3}(U|J|Z|R)\d{7}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate check digit and return it for the 10 digit owner code and
     serial number."""
     number = compact(number)
@@ -67,7 +68,7 @@ def calc_check_digit(number):
         for i, n in enumerate(number)) % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Validate the given number (unicode) for conformity to ISO 6346."""
     number = compact(number)
     if len(number) != 11:
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the number conforms to the standard ISO6346. Unlike
     the validate function, this will not raise ValidationError(s)."""
     try:
@@ -88,7 +89,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:4], number[4:-1], number[-1:]))

--- a/stdnum/iso7064/mod_11_10.py
+++ b/stdnum/iso7064/mod_11_10.py
@@ -34,11 +34,12 @@ For a module that can do generic Mod x+1, x calculations see the
 >>> validate('002006673085')
 '002006673085'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. A valid number should have a checksum of 1."""
     check = 5
     for n in number:
@@ -46,13 +47,13 @@ def checksum(number):
     return check
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     return str((1 - ((checksum(number) or 10) * 2) % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check whether the check digit is valid."""
     try:
         valid = checksum(number) == 1
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the check digit is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/iso7064/mod_11_2.py
+++ b/stdnum/iso7064/mod_11_2.py
@@ -36,11 +36,12 @@ For a module that can do generic Mod x, 2 calculations see the
 >>> checksum('079X')
 1
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. A valid number should have a checksum of 1."""
     check = 0
     for n in number:
@@ -48,14 +49,14 @@ def checksum(number):
     return check
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     c = (1 - 2 * checksum(number)) % 11
     return 'X' if c == 10 else str(c)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check whether the check digit is valid."""
     try:
         valid = checksum(number) == 1
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the check digit is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/iso7064/mod_37_2.py
+++ b/stdnum/iso7064/mod_37_2.py
@@ -39,11 +39,12 @@ algorithm. For example Mod 11, 2:
 >>> checksum('079X', alphabet='0123456789X')
 1
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def checksum(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
+def checksum(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*') -> int:
     """Calculate the checksum. A valid number should have a checksum of 1."""
     modulus = len(alphabet)
     check = 0
@@ -52,14 +53,14 @@ def checksum(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
     return check
 
 
-def calc_check_digit(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
+def calc_check_digit(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*') -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     modulus = len(alphabet)
     return alphabet[(1 - 2 * checksum(number, alphabet)) % modulus]
 
 
-def validate(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
+def validate(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*') -> str:
     """Check whether the check digit is valid."""
     try:
         valid = checksum(number, alphabet) == 1
@@ -70,7 +71,7 @@ def validate(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
     return number
 
 
-def is_valid(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*'):
+def is_valid(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ*') -> bool:
     """Check whether the check digit is valid."""
     try:
         return bool(validate(number, alphabet))

--- a/stdnum/iso7064/mod_37_36.py
+++ b/stdnum/iso7064/mod_37_36.py
@@ -37,11 +37,12 @@ algorithm. For example Mod 11, 10:
 >>> validate('002006673085', alphabet='0123456789')
 '002006673085'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def checksum(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
+def checksum(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ') -> int:
     """Calculate the checksum. A valid number should have a checksum of 1."""
     modulus = len(alphabet)
     check = modulus // 2
@@ -50,14 +51,14 @@ def checksum(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
     return check
 
 
-def calc_check_digit(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
+def calc_check_digit(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ') -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     modulus = len(alphabet)
     return alphabet[(1 - ((checksum(number, alphabet) or modulus) * 2) % (modulus + 1)) % modulus]
 
 
-def validate(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
+def validate(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ') -> str:
     """Check whether the check digit is valid."""
     try:
         valid = checksum(number, alphabet) == 1
@@ -68,7 +69,7 @@ def validate(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
     return number
 
 
-def is_valid(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
+def is_valid(number: str, alphabet: str = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ') -> bool:
     """Check whether the check digit is valid."""
     try:
         return bool(validate(number, alphabet))

--- a/stdnum/iso7064/mod_97_10.py
+++ b/stdnum/iso7064/mod_97_10.py
@@ -33,28 +33,29 @@ valid if the number modulo 97 is 1. As such it has two check digits.
 >>> calc_check_digits('22181321402534321446701611')
 '35'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def _to_base10(number):
+def _to_base10(number: str) -> str:
     """Prepare the number to its base10 representation."""
     return ''.join(
         str(int(x, 36)) for x in number)
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum. A valid number should have a checksum of 1."""
     return int(_to_base10(number)) % 97
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the extra digits that should be appended to the number to
     make it a valid number."""
     return '%02d' % (98 - checksum(number + '00'))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check whether the check digit is valid."""
     try:
         valid = checksum(number) == 1
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the check digit is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/isrc.py
+++ b/stdnum/isrc.py
@@ -35,6 +35,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -74,13 +75,13 @@ _country_codes = set(_iso_3116_1_country_codes + [
 ])
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the ISRC to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid ISRC. This checks the length,
     the alphabet, and the country code but does not check if the registrant
     code is known."""
@@ -95,7 +96,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISRC."""
     try:
         return bool(validate(number))
@@ -103,7 +104,7 @@ def is_valid(number):
         return False
 
 
-def format(number, separator='-'):
+def format(number: str, separator: str = '-') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return separator.join((number[0:2], number[2:5], number[5:7], number[7:]))

--- a/stdnum/issn.py
+++ b/stdnum/issn.py
@@ -48,19 +48,20 @@ InvalidLength: ...
 >>> to_ean('0264-3596')
 '9770264359008'
 """
+from __future__ import annotations
 
 from stdnum import ean
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the ISSN to the minimal representation. This strips the number
     of any valid ISSN separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the ISSN check digit for 8-digit numbers. The number passed
     should not have the check digit included."""
     check = (11 - sum((8 - i) * int(n)
@@ -68,7 +69,7 @@ def calc_check_digit(number):
     return 'X' if check == 10 else str(check)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ISSN. This checks the length and
     whether the check digit is correct."""
     number = compact(number)
@@ -81,7 +82,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ISSN."""
     try:
         return bool(validate(number))
@@ -89,13 +90,13 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:4] + '-' + number[4:]
 
 
-def to_ean(number, issue_code='00'):
+def to_ean(number: str, issue_code: str = '00') -> str:
     """Convert the number to EAN-13 format."""
     number = '977' + validate(number)[:-1] + issue_code
     return number + ean.calc_check_digit(number)

--- a/stdnum/it/__init__.py
+++ b/stdnum/it/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Italian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.it import iva as vat  # noqa: F401

--- a/stdnum/it/aic.py
+++ b/stdnum/it/aic.py
@@ -46,6 +46,7 @@ More information:
 >>> from_base32('009CVD')
 '000307052'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -55,12 +56,12 @@ from stdnum.util import clean, isdigits
 _base32_alphabet = '0123456789BCDFGHJKLMNPQRSTUVWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     return clean(number, ' ').upper().strip()
 
 
-def from_base32(number):
+def from_base32(number: str) -> str:
     """Convert a BASE32 representation of an AIC to a BASE10 one."""
     number = compact(number)
     if not all(x in _base32_alphabet for x in number):
@@ -70,7 +71,7 @@ def from_base32(number):
     return str(s).zfill(9)
 
 
-def to_base32(number):
+def to_base32(number: str) -> str:
     """Convert a BASE10 representation of an AIC to a BASE32 one."""
     number = compact(number)
     if not isdigits(number):
@@ -84,7 +85,7 @@ def to_base32(number):
     return res.zfill(6)
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the BASE10 AIC code."""
     number = compact(number)
     weights = (1, 2, 1, 2, 1, 2, 1, 2)
@@ -92,7 +93,7 @@ def calc_check_digit(number):
                for x in (w * int(n) for w, n in zip(weights, number))) % 10)
 
 
-def validate_base10(number):
+def validate_base10(number: str) -> str:
     """Check if a string is a valid BASE10 representation of an AIC."""
     number = compact(number)
     if len(number) != 9:
@@ -106,7 +107,7 @@ def validate_base10(number):
     return number
 
 
-def validate_base32(number):
+def validate_base32(number: str) -> str:
     """Check if a string is a valid BASE32 representation of an AIC."""
     number = compact(number)
     if len(number) != 6:
@@ -114,7 +115,7 @@ def validate_base32(number):
     return validate_base10(from_base32(number))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if a string is a valid AIC. BASE10 is the canonical form and
     is 9 chars long, while BASE32 is 6 chars."""
     number = compact(number)
@@ -124,7 +125,7 @@ def validate(number):
         return validate_base10(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the given string is a valid AIC code."""
     try:
         return bool(validate(number))

--- a/stdnum/it/codicefiscale.py
+++ b/stdnum/it/codicefiscale.py
@@ -54,10 +54,12 @@ InvalidChecksum: ...
 >>> calc_check_digit('RCCMNL83S18D969')
 'H'
 """
+from __future__ import annotations
 
 import datetime
 import re
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.it import iva
 from stdnum.util import clean
@@ -91,13 +93,13 @@ _odd_values.update(
 del values
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -:').strip().upper()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Compute the control code for the given personal number. The passed
     number should be the first 15 characters of a fiscal code."""
     code = sum(_odd_values[x] if n % 2 == 0 else _even_values[x]
@@ -105,7 +107,7 @@ def calc_check_digit(number):
     return 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[code % 26]
 
 
-def get_birth_date(number, minyear=1920):
+def get_birth_date(number: str, minyear: int = 1920) -> datetime.date:
     """Get the birth date from the person's fiscal code.
 
     Only the last two digits of the year are stored in the number. The dates
@@ -132,7 +134,7 @@ def get_birth_date(number, minyear=1920):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the gender of the person's fiscal code.
 
     >>> get_gender('RCCMNL83S18D969H')
@@ -146,7 +148,7 @@ def get_gender(number):
     return 'M' if int(number[9:11]) < 32 else 'F'
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the given fiscal code is valid. This checks the length and
     whether the check digit is correct."""
     number = compact(number)
@@ -163,7 +165,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the given fiscal code is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/it/iva.py
+++ b/stdnum/it/iva.py
@@ -33,13 +33,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -:').upper().strip()
@@ -48,7 +49,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/jp/__init__.py
+++ b/stdnum/jp/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Japanese numbers."""
+from __future__ import annotations
+
 from stdnum.jp import cn as vat  # noqa: F401

--- a/stdnum/jp/cn.py
+++ b/stdnum/jp/cn.py
@@ -39,18 +39,19 @@ InvalidChecksum: ...
 >>> format('5835678256246')
 '5-8356-7825-6246'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '- ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have
     the check digit included."""
     weights = (1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2)
@@ -58,7 +59,7 @@ def calc_check_digit(number):
     return str(9 - s)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is valid. This checks the length and check
     digit."""
     number = compact(number)
@@ -71,7 +72,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CN."""
     try:
         return bool(validate(number))
@@ -79,7 +80,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join(

--- a/stdnum/ke/__init__.py
+++ b/stdnum/ke/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Kenyan numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.ke import pin as vat  # noqa: F401

--- a/stdnum/ke/pin.py
+++ b/stdnum/ke/pin.py
@@ -49,6 +49,7 @@ InvalidFormat: ...
 >>> format('a004416331m')
 'A004416331M'
 """
+from __future__ import annotations
 
 import re
 
@@ -62,13 +63,13 @@ from stdnum.util import clean
 _pin_re = re.compile(r'^[A|P]{1}[0-9]{9}[A-Z]{1}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Kenya PIN number.
 
     This checks the length and formatting.
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Kenya PIN number."""
     try:
         return bool(validate(number))
@@ -90,6 +91,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/kr/__init__.py
+++ b/stdnum/kr/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of South Korean numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.kr import brn as vat  # noqa: F401

--- a/stdnum/kr/brn.py
+++ b/stdnum/kr/brn.py
@@ -43,12 +43,13 @@ InvalidLength: ...
 >>> format('1348672683')
 '134-86-72683'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -57,7 +58,7 @@ def compact(number):
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid South Korea BRN number.
 
     This checks the length and formatting.
@@ -72,7 +73,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid South Korea BRN number."""
     try:
         return bool(validate(number))
@@ -80,7 +81,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:3], number[3:5], number[5:]])

--- a/stdnum/kr/rrn.py
+++ b/stdnum/kr/rrn.py
@@ -44,6 +44,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import datetime
 
@@ -51,20 +52,20 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5)
     check = sum(w * int(n) for w, n in zip(weights, number))
     return str((11 - (check % 11)) % 10)
 
 
-def get_birth_date(number, allow_future=True):
+def get_birth_date(number: str, allow_future: bool = True) -> datetime.date:
     """Split the date parts from the number and return the birth date. If
     allow_future is False birth dates in the future are rejected."""
     number = compact(number)
@@ -90,7 +91,7 @@ def get_birth_date(number, allow_future=True):
     return date_of_birth
 
 
-def validate(number, allow_future=True):
+def validate(number: str, allow_future: bool = True) -> str:
     """Check if the number is a valid RNN. This checks the length, formatting
     and check digit. If allow_future is False birth dates in the future are
     rejected."""
@@ -110,7 +111,7 @@ def validate(number, allow_future=True):
     return number
 
 
-def is_valid(number, allow_future=True):
+def is_valid(number: str, allow_future: bool = True) -> bool:
     """Check if the number provided is valid."""
     try:
         return bool(validate(number, allow_future))
@@ -118,7 +119,7 @@ def is_valid(number, allow_future=True):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     if len(number) == 13:

--- a/stdnum/lei.py
+++ b/stdnum/lei.py
@@ -39,19 +39,20 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding white space."""
     return clean(number, ' -').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is valid. This checks the length, format and check
     digits."""
     number = compact(number)
@@ -59,7 +60,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/li/peid.py
+++ b/stdnum/li/peid.py
@@ -38,18 +38,19 @@ Traceback (most recent call last):
     ...
 InvalidLength: The number has an invalid length.
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' .').strip().lstrip('0')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the given fiscal code is valid."""
     number = compact(number)
     if len(number) < 4 or len(number) > 12:
@@ -60,7 +61,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the given fiscal code is valid."""
     try:
         return bool(validate(number))

--- a/stdnum/lt/__init__.py
+++ b/stdnum/lt/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Lithuanian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.lt import pvm as vat  # noqa: F401

--- a/stdnum/lt/asmens.py
+++ b/stdnum/lt/asmens.py
@@ -36,19 +36,20 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.ee.ik import calc_check_digit, get_birth_date
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def validate(number, validate_birth_date=True):
+def validate(number: str, validate_birth_date: bool = True) -> str:
     """Check if the number provided is valid. This checks the length,
     formatting, embedded date and check digit."""
     number = compact(number)
@@ -63,7 +64,7 @@ def validate(number, validate_birth_date=True):
     return number
 
 
-def is_valid(number, validate_birth_date=True):
+def is_valid(number: str, validate_birth_date: bool = True) -> bool:
     """Check if the number provided is valid. This checks the length,
     formatting, embedded date and check digit."""
     try:

--- a/stdnum/lt/pvm.py
+++ b/stdnum/lt/pvm.py
@@ -36,12 +36,13 @@ InvalidChecksum: ...
 >>> validate('100004801610')  # second step in check digit calculation
 '100004801610'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -50,7 +51,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     check = sum((1 + i % 9) * int(n) for i, n in enumerate(number)) % 11
@@ -59,7 +60,7 @@ def calc_check_digit(number):
     return str(check % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/lu/__init__.py
+++ b/stdnum/lu/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Luxembourgian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.lu import tva as vat  # noqa: F401

--- a/stdnum/lu/tva.py
+++ b/stdnum/lu/tva.py
@@ -31,12 +31,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' :.-').upper().strip()
@@ -45,12 +46,12 @@ def compact(number):
     return number
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the number."""
     return '%02d' % (int(number) % 89)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/luhn.py
+++ b/stdnum/luhn.py
@@ -43,22 +43,23 @@ InvalidChecksum: ...
 >>> checksum('1234', alphabet='0123456789abcdef')
 14
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
 
-def checksum(number, alphabet='0123456789'):
+def checksum(number: str, alphabet: str = '0123456789') -> int:
     """Calculate the Luhn checksum over the provided number. The checksum
     is returned as an int. Valid numbers should have a checksum of 0."""
     n = len(alphabet)
-    number = tuple(alphabet.index(i)
+    digits = tuple(alphabet.index(i)
                    for i in reversed(str(number)))
-    return (sum(number[::2]) +
+    return (sum(digits[::2]) +
             sum(sum(divmod(i * 2, n))
-                for i in number[1::2])) % n
+                for i in digits[1::2])) % n
 
 
-def validate(number, alphabet='0123456789'):
+def validate(number: str, alphabet: str = '0123456789') -> str:
     """Check if the number provided passes the Luhn checksum."""
     if not bool(number):
         raise InvalidFormat()
@@ -71,7 +72,7 @@ def validate(number, alphabet='0123456789'):
     return number
 
 
-def is_valid(number, alphabet='0123456789'):
+def is_valid(number: str, alphabet: str = '0123456789') -> bool:
     """Check if the number passes the Luhn checksum."""
     try:
         return bool(validate(number, alphabet))
@@ -79,7 +80,7 @@ def is_valid(number, alphabet='0123456789'):
         return False
 
 
-def calc_check_digit(number, alphabet='0123456789'):
+def calc_check_digit(number: str, alphabet: str = '0123456789') -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     ck = checksum(str(number) + alphabet[0], alphabet)

--- a/stdnum/lv/__init__.py
+++ b/stdnum/lv/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Latvian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.lv import pvn as vat  # noqa: F401

--- a/stdnum/lv/pvn.py
+++ b/stdnum/lv/pvn.py
@@ -38,6 +38,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import datetime
 
@@ -50,7 +51,7 @@ from stdnum.util import clean, isdigits
 # https://www6.vid.gov.lv/VID_PDB?aspxerrorpath=/vid_pdb/pvn.asp
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -59,13 +60,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum for legal entities."""
     weights = (9, 1, 4, 8, 3, 10, 2, 5, 7, 6, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def calc_check_digit_pers(number):
+def calc_check_digit_pers(number: str) -> str:
     """Calculate the check digit for personal codes. The number passed
     should not have the check digit included."""
     # note that this algorithm has not been confirmed by an independent source
@@ -74,7 +75,7 @@ def calc_check_digit_pers(number):
     return str(check % 11 % 10)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     day = int(number[0:2])
@@ -87,7 +88,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -108,7 +109,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ma/__init__.py
+++ b/stdnum/ma/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Moroccan numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ma import ice as vat  # noqa: F401

--- a/stdnum/ma/ice.py
+++ b/stdnum/ma/ice.py
@@ -59,13 +59,14 @@ InvalidChecksum: ...
 >>> format('00 21 36 09 30 00 040')
 '002136093000040'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators, removes surrounding
@@ -74,7 +75,7 @@ def compact(number):
     return clean(number, ' ')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Morocco ICE number.
 
     This checks the length and formatting.
@@ -89,7 +90,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Morocco ICE number."""
     try:
         return bool(validate(number))
@@ -97,6 +98,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number).zfill(15)

--- a/stdnum/mac.py
+++ b/stdnum/mac.py
@@ -42,6 +42,7 @@ False
 >>> get_iab('d0:50:99:84:a2:a0')
 '84A2A0'
 """
+from __future__ import annotations
 
 import re
 
@@ -53,14 +54,14 @@ from stdnum.util import clean
 _mac_re = re.compile('^([0-9a-f]{2}:){5}[0-9a-f]{2}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the MAC address to the minimal, consistent representation."""
     number = clean(number, ' ').strip().lower().replace('-', ':')
     # zero-pad single-digit elements
     return ':'.join('0' + n if len(n) == 1 else n for n in number.split(':'))
 
 
-def _lookup(number):
+def _lookup(number: str) -> tuple[str, str]:
     """Look up the manufacturer in the IEEE OUI registry."""
     number = compact(number).replace(':', '').upper()
     info = numdb.get('oui').info(number)
@@ -72,23 +73,23 @@ def _lookup(number):
         raise InvalidComponent()
 
 
-def get_manufacturer(number):
+def get_manufacturer(number: str) -> str:
     """Look up the manufacturer in the IEEE OUI registry."""
     return _lookup(number)[1]
 
 
-def get_oui(number):
+def get_oui(number: str) -> str:
     """Return the OUI (organization unique ID) part of the address."""
     return _lookup(number)[0]
 
 
-def get_iab(number):
+def get_iab(number: str) -> str:
     """Return the IAB (individual address block) part of the address."""
     number = compact(number).replace(':', '').upper()
     return number[len(get_oui(number)):]
 
 
-def is_unicast(number):
+def is_unicast(number: str) -> bool:
     """Check whether the number is a unicast address.
 
     Unicast addresses are received by one node in a network (LAN)."""
@@ -96,7 +97,7 @@ def is_unicast(number):
     return int(number[:2], 16) & 1 == 0
 
 
-def is_multicast(number):
+def is_multicast(number: str) -> bool:
     """Check whether the number is a multicast address.
 
     Multicast addresses are meant to be received by (potentially) multiple
@@ -104,7 +105,7 @@ def is_multicast(number):
     return not is_unicast(number)
 
 
-def is_broadcast(number):
+def is_broadcast(number: str) -> bool:
     """Check whether the number is the broadcast address.
 
     Broadcast addresses are meant to be received by all nodes in a network."""
@@ -112,18 +113,18 @@ def is_broadcast(number):
     return number == 'ff:ff:ff:ff:ff:ff'
 
 
-def is_universally_administered(number):
+def is_universally_administered(number: str) -> bool:
     """Check if the address is supposed to be assigned by the manufacturer."""
     number = compact(number)
     return int(number[:2], 16) & 2 == 0
 
 
-def is_locally_administered(number):
+def is_locally_administered(number: str) -> bool:
     """Check if the address is meant to be configured by an administrator."""
     return not is_universally_administered(number)
 
 
-def validate(number, validate_manufacturer=None):
+def validate(number: str, validate_manufacturer: bool | None = None) -> str:
     """Check if the number provided is a valid MAC address.
 
     The existence of the manufacturer is by default only checked for
@@ -141,7 +142,7 @@ def validate(number, validate_manufacturer=None):
     return number
 
 
-def is_valid(number, validate_manufacturer=None):
+def is_valid(number: str, validate_manufacturer: bool | None = None) -> bool:
     """Check if the number provided is a valid IBAN."""
     try:
         return bool(validate(number, validate_manufacturer=validate_manufacturer))
@@ -149,6 +150,6 @@ def is_valid(number, validate_manufacturer=None):
         return False
 
 
-def to_eui48(number):
+def to_eui48(number: str) -> str:
     """Convert the MAC address to EUI-48 format."""
     return compact(number).upper().replace(':', '-')

--- a/stdnum/mc/__init__.py
+++ b/stdnum/mc/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Monacan numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.mc import tva as vat  # noqa: F401

--- a/stdnum/mc/tva.py
+++ b/stdnum/mc/tva.py
@@ -33,18 +33,19 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.fr import tva
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return 'FR' + tva.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = tva.validate(number)
@@ -53,7 +54,7 @@ def validate(number):
     return 'FR' + number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/md/idno.py
+++ b/stdnum/md/idno.py
@@ -36,24 +36,25 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is valid. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is valid. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/me/__init__.py
+++ b/stdnum/me/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Montenegro numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.me import pib as vat  # noqa: F401

--- a/stdnum/me/iban.py
+++ b/stdnum/me/iban.py
@@ -36,6 +36,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 from stdnum import iban
 from stdnum.exceptions import *
@@ -48,12 +49,12 @@ compact = iban.compact
 format = iban.format
 
 
-def _checksum(number):
+def _checksum(number: str) -> int:
     """Calculate the check digits over the provided part of the number."""
     return int(number) % 97
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Montenegro IBAN."""
     number = iban.validate(number, check_country=False)
     if not number.startswith('ME'):
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Montenegro IBAN."""
     try:
         return bool(validate(number))

--- a/stdnum/me/pib.py
+++ b/stdnum/me/pib.py
@@ -37,12 +37,13 @@ InvalidChecksum: ...
 >>> format('02655284')
 '02655284'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -51,13 +52,13 @@ def compact(number):
     return clean(number, ' ')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     weights = (8, 7, 6, 5, 4, 3, 2)
     return str((-sum(w * int(n) for w, n in zip(weights, number))) % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Montenegro PIB number."""
     number = compact(number)
     if len(number) != 8:
@@ -69,7 +70,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Montenegro PIB number."""
     try:
         return bool(validate(number))
@@ -77,6 +78,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/meid.py
+++ b/stdnum/meid.py
@@ -37,7 +37,9 @@ InvalidChecksum: ...
 >>> format('af0123450abcDEC', format='dec', add_check_digit=True)
 '29360 87365 0070 3710 0'
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
@@ -45,20 +47,20 @@ from stdnum.util import clean, isdigits
 _hex_alphabet = '0123456789ABCDEF'
 
 
-def _cleanup(number):
+def _cleanup(number: str) -> str:
     """Remove any grouping information from the number and removes surrounding
     whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def _ishex(number):
+def _ishex(number: str) -> bool:
     for x in number:
         if x not in _hex_alphabet:
             return False
     return True
 
 
-def _parse(number):
+def _parse(number: str) -> tuple[str, str]:
     number = _cleanup(number)
     if len(number) in (14, 15):
         # 14 or 15 digit hex representation
@@ -74,7 +76,7 @@ def _parse(number):
         raise InvalidLength()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number. The number should not
     already have a check digit."""
     # both the 18-digit decimal format and the 14-digit hex format
@@ -86,7 +88,7 @@ def calc_check_digit(number):
         return luhn.calc_check_digit(number, alphabet=_hex_alphabet)
 
 
-def compact(number, strip_check_digit=True):
+def compact(number: str, strip_check_digit: bool = True) -> str:
     """Convert the MEID number to the minimal (hexadecimal) representation.
     This strips grouping information, removes surrounding whitespace and
     converts to hexadecimal if needed. If the check digit is to be preserved
@@ -105,7 +107,7 @@ def compact(number, strip_check_digit=True):
     return number + cd
 
 
-def validate(number, strip_check_digit=True):
+def validate(number: str, strip_check_digit: bool = True) -> str:
     """Check if the number is a valid MEID number. This converts the
     representation format of the number (if it is decimal it is not converted
     to hexadecimal)."""
@@ -136,7 +138,7 @@ def validate(number, strip_check_digit=True):
     return number + cd
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid MEID number."""
     try:
         return bool(validate(number))
@@ -144,7 +146,12 @@ def is_valid(number):
         return False
 
 
-def format(number, separator=' ', format=None, add_check_digit=False):
+def format(
+    number: str,
+    separator: str = ' ',
+    format: t.Literal['dec', 'hex'] | None = None,
+    add_check_digit: bool = False,
+) -> str:
     """Reformat the number to the standard presentation format. The separator
     used can be provided. If the format is specified (either 'hex' or 'dec')
     the number is reformatted in that format, otherwise the current
@@ -167,22 +174,23 @@ def format(number, separator=' ', format=None, add_check_digit=False):
     if add_check_digit and not cd:
         cd = calc_check_digit(number)
     # split number according to format
+    parts: t.Iterable[str]
     if len(number) == 14:
-        number = [number[i * 2:i * 2 + 2]
-                  for i in range(7)] + [cd]
+        parts = [number[i * 2:i * 2 + 2]
+                 for i in range(7)] + [cd]
     else:
-        number = (number[:5], number[5:10], number[10:14], number[14:], cd)
-    return separator.join(x for x in number if x)
+        parts = (number[:5], number[5:10], number[10:14], number[14:], cd)
+    return separator.join(x for x in parts if x)
 
 
-def to_binary(number):
+def to_binary(number: str) -> bytes:
     """Convert the number to its binary representation (without the check
     digit)."""
     from binascii import a2b_hex
     return a2b_hex(compact(number, strip_check_digit=True))
 
 
-def to_pseudo_esn(number):
+def to_pseudo_esn(number: str) -> str:
     """Convert the provided MEID to a pseudo ESN (pESN). The ESN is returned
     in compact hexadecimal representation."""
     # return the last 6 digits of the SHA1  hash prefixed with the reserved

--- a/stdnum/mk/__init__.py
+++ b/stdnum/mk/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of North Macedonia numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.mk import edb as vat  # noqa: F401

--- a/stdnum/mk/edb.py
+++ b/stdnum/mk/edb.py
@@ -42,12 +42,13 @@ InvalidChecksum: ...
 >>> format('MK4057009501106')  # ASCII letters
 '4057009501106'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -61,14 +62,14 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
     total = sum(int(n) * w for n, w in zip(number, weights))
     return str((-total % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid North Macedonia ЕДБ number.
 
     This checks the length, formatting and check digit.
@@ -83,7 +84,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid North Macedonia ЕДБ number."""
     try:
         return bool(validate(number))
@@ -91,6 +92,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/mt/vat.py
+++ b/stdnum/mt/vat.py
@@ -29,12 +29,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -43,13 +44,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (3, 4, 6, 7, 8, 9, 10, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 37
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -62,7 +63,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/mu/nid.py
+++ b/stdnum/mu/nid.py
@@ -37,6 +37,7 @@ More information:
 
 * https://mnis.govmu.org/English/ID%20Card/Pages/default.aspx
 """
+from __future__ import annotations
 
 import datetime
 import re
@@ -52,20 +53,20 @@ _nid_re = re.compile('^[A-Z][0-9]+[0-9A-Z]$')
 _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, ' ').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     check = sum((14 - i) * _alphabet.index(n)
                 for i, n in enumerate(number[:13]))
     return _alphabet[(17 - check) % 17]
 
 
-def _get_date(number):
+def _get_date(number: str) -> datetime.date:
     """Convert the part of the number that represents a date into a
     datetime. Note that the century may be incorrect."""
     day = int(number[1:3])
@@ -77,7 +78,7 @@ def _get_date(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ID number."""
     number = compact(number)
     if len(number) != 14:
@@ -90,7 +91,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid RFC."""
     try:
         return bool(validate(number))

--- a/stdnum/mx/__init__.py
+++ b/stdnum/mx/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Mexican numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.mx import curp as personalid  # noqa: F401

--- a/stdnum/mx/curp.py
+++ b/stdnum/mx/curp.py
@@ -41,10 +41,12 @@ datetime.date(1931, 8, 20)
 >>> get_gender('BOXW310820HNERXN09')
 'M'
 """
+from __future__ import annotations
 
 import datetime
 import re
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean
 
@@ -66,13 +68,13 @@ _valid_states = set('''
 '''.split())
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, '-_ ').upper().strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     year = int(number[4:6])
@@ -88,7 +90,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the gender (M/F) from the person's CURP."""
     number = compact(number)
     if number[10] == 'H':
@@ -103,13 +105,13 @@ def get_gender(number):
 _alphabet = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ'
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     check = sum(_alphabet.index(c) * (18 - i) for i, c in enumerate(number[:17]))
     return str((10 - check % 10) % 10)
 
 
-def validate(number, validate_check_digits=True):
+def validate(number: str, validate_check_digits: bool = True) -> str:
     """Check if the number is a valid CURP."""
     number = compact(number)
     if len(number) != 18:
@@ -127,7 +129,7 @@ def validate(number, validate_check_digits=True):
     return number
 
 
-def is_valid(number, validate_check_digits=True):
+def is_valid(number: str, validate_check_digits: bool = True) -> bool:
     """Check if the number provided is a valid CURP."""
     try:
         return bool(validate(number, validate_check_digits))

--- a/stdnum/mx/rfc.py
+++ b/stdnum/mx/rfc.py
@@ -59,6 +59,7 @@ InvalidChecksum: ...
 >>> format('GODE561231GR8')
 'GODE 561231 GR8'
 """
+from __future__ import annotations
 
 import datetime
 import re
@@ -81,13 +82,13 @@ _name_blacklist = set([
 _alphabet = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ Ñ'
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, '-_ ').upper().strip()
 
 
-def _get_date(number):
+def _get_date(number: str) -> datetime.date:
     """Convert the part of the number that represents a date into a
     datetime. Note that the century may be incorrect."""
     year = int(number[0:2])
@@ -99,7 +100,7 @@ def _get_date(number):
         raise InvalidComponent()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     number = ('   ' + number)[-12:]
@@ -107,7 +108,7 @@ def calc_check_digit(number):
     return _alphabet[(11 - check) % 11]
 
 
-def validate(number, validate_check_digits=False):
+def validate(number: str, validate_check_digits: bool = False) -> str:
     """Check if the number is a valid RFC."""
     number = compact(number)
     if len(number) in (10, 13):
@@ -132,7 +133,7 @@ def validate(number, validate_check_digits=False):
     return number
 
 
-def is_valid(number, validate_check_digits=False):
+def is_valid(number: str, validate_check_digits: bool = False) -> bool:
     """Check if the number provided is a valid RFC."""
     try:
         return bool(validate(number, validate_check_digits))
@@ -140,7 +141,7 @@ def is_valid(number, validate_check_digits=False):
         return False
 
 
-def format(number, separator=' '):
+def format(number: str, separator: str = ' ') -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     if len(number) == 12:

--- a/stdnum/my/nric.py
+++ b/stdnum/my/nric.py
@@ -40,6 +40,7 @@ InvalidComponent: ...
 >>> format('770305021234')
 '770305-02-1234'
 """
+from __future__ import annotations
 
 import datetime
 
@@ -47,13 +48,13 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -*').strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date.
     Note that in some cases it may return the registration date instead of
     the birth date and it may be a century off."""
@@ -72,7 +73,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_birth_place(number):
+def get_birth_place(number: str) -> dict[str, str]:
     """Use the number to look up the place of birth of the person. This can
     either be a state or federal territory within Malaysia or a country
     outside of Malaysia."""
@@ -84,7 +85,7 @@ def get_birth_place(number):
     return results
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid NRIC number. This checks the length,
     formatting and birth date and place."""
     number = compact(number)
@@ -97,7 +98,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid NRIC number."""
     try:
         return bool(validate(number))
@@ -105,7 +106,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:6] + '-' + number[6:8] + '-' + number[8:]

--- a/stdnum/nl/__init__.py
+++ b/stdnum/nl/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Dutch numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.nl import btw as vat  # noqa: F401

--- a/stdnum/nl/brin.py
+++ b/stdnum/nl/brin.py
@@ -44,6 +44,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -57,13 +58,13 @@ from stdnum.util import clean
 _brin_re = re.compile(r'^(?P<brin>[0-9]{2}[A-Z]{2})(?P<location>[0-9]{2})?$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Brun number. This currently does not
     check whether the number points to a registered school."""
     number = compact(number)
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Brun number."""
     try:
         return bool(validate(number))

--- a/stdnum/nl/bsn.py
+++ b/stdnum/nl/bsn.py
@@ -43,25 +43,26 @@ InvalidLength: ...
 >>> format('111222333')
 '1112.22.333'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip().zfill(9)
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum over the number. A valid number should have
     a checksum of 0."""
     return (sum((9 - i) * int(n) for i, n in enumerate(number[:-1])) -
             int(number[-1])) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid BSN. This checks the length and whether
     the check digit is correct."""
     number = compact(number)
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid BSN."""
     try:
         return bool(validate(number))
@@ -82,7 +83,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the passed number to the standard presentation format."""
     number = compact(number)
     return number[:4] + '.' + number[4:6] + '.' + number[6:]

--- a/stdnum/nl/btw.py
+++ b/stdnum/nl/btw.py
@@ -46,6 +46,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_97_10
@@ -53,7 +54,7 @@ from stdnum.nl import bsn
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -62,7 +63,7 @@ def compact(number):
     return bsn.compact(number[:-3]) + number[-3:]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid btw number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid btw number."""
     try:
         return bool(validate(number))

--- a/stdnum/nl/identiteitskaartnummer.py
+++ b/stdnum/nl/identiteitskaartnummer.py
@@ -53,6 +53,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -60,13 +61,13 @@ from stdnum.exceptions import *
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding white space."""
     return clean(number, ' ').strip().upper()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid passport number.
     This checks the length, formatting and check digit."""
     number = compact(number)
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Dutch passport number."""
     try:
         return bool(validate(number))

--- a/stdnum/nl/onderwijsnummer.py
+++ b/stdnum/nl/onderwijsnummer.py
@@ -42,6 +42,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.nl.bsn import checksum, compact
@@ -51,7 +52,7 @@ from stdnum.util import isdigits
 __all__ = ['compact', 'validate', 'is_valid']
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid onderwijsnummer. This checks the length
     and whether the check digit is correct and whether it starts with the
     right sequence."""
@@ -67,7 +68,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid onderwijsnummer."""
     try:
         return bool(validate(number))

--- a/stdnum/nl/postcode.py
+++ b/stdnum/nl/postcode.py
@@ -39,6 +39,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -52,7 +53,7 @@ _postcode_re = re.compile(r'^(?P<pt1>[1-9][0-9]{3})(?P<pt2>[A-Z]{2})$')
 _postcode_blacklist = ('SA', 'SD', 'SS')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -61,7 +62,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is in the correct format. This currently does not
     check whether the code corresponds to a real address."""
     number = compact(number)
@@ -73,7 +74,7 @@ def validate(number):
     return '%s %s' % (match.group('pt1'), match.group('pt2'))
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid postal code."""
     try:
         return bool(validate(number))

--- a/stdnum/no/__init__.py
+++ b/stdnum/no/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Norwegian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.no import fodselsnummer as personalid  # noqa: F401

--- a/stdnum/no/fodselsnummer.py
+++ b/stdnum/no/fodselsnummer.py
@@ -41,32 +41,34 @@ InvalidChecksum: ...
 >>> format('15108695077')
 '151086 95077'
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -:')
 
 
-def calc_check_digit1(number):
+def calc_check_digit1(number: str) -> str:
     """Calculate the first check digit for the number."""
     weights = (3, 7, 6, 1, 8, 9, 4, 5, 2)
     return str((11 - sum(w * int(n) for w, n in zip(weights, number))) % 11)
 
 
-def calc_check_digit2(number):
+def calc_check_digit2(number: str) -> str:
     """Calculate the second check digit for the number."""
     weights = (5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
     return str((11 - sum(w * int(n) for w, n in zip(weights, number))) % 11)
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if int(number[8]) % 2:
@@ -75,7 +77,7 @@ def get_gender(number):
         return 'F'
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Determine and return the birth date."""
     number = compact(number)
     day = int(number[0:2])
@@ -111,7 +113,7 @@ def get_birth_date(number):
         raise InvalidComponent('The number does not contain valid birth date information.')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid birth number."""
     number = compact(number)
     if len(number) != 11:
@@ -128,7 +130,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid birth number."""
     try:
         return bool(validate(number))
@@ -136,7 +138,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:6] + ' ' + number[6:]

--- a/stdnum/no/iban.py
+++ b/stdnum/no/iban.py
@@ -43,6 +43,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum import iban
 from stdnum.exceptions import *
@@ -56,7 +57,7 @@ compact = iban.compact
 format = iban.format
 
 
-def to_kontonr(number):
+def to_kontonr(number: str) -> str:
     """Return the Norwegian bank account number part of the number."""
     number = compact(number)
     if not number.startswith('NO'):
@@ -64,14 +65,14 @@ def to_kontonr(number):
     return number[4:]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid Norwegian IBAN."""
     number = iban.validate(number, check_country=False)
     kontonr.validate(to_kontonr(number))
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid Norwegian IBAN."""
     try:
         return bool(validate(number))

--- a/stdnum/no/kontonr.py
+++ b/stdnum/no/kontonr.py
@@ -41,13 +41,14 @@ InvalidChecksum: ...
 >>> to_iban('8601 11 17947')
 'NO93 8601 11 17947'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' .-').strip()
@@ -56,13 +57,13 @@ def compact(number):
     return number
 
 
-def _calc_check_digit(number):
+def _calc_check_digit(number: str) -> str:
     """Calculate the check digit for the 11-digit number."""
     weights = (6, 7, 8, 9, 4, 5, 6, 7, 8, 9)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid bank account number."""
     number = compact(number)
     if not isdigits(number):
@@ -77,7 +78,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid bank account number."""
     try:
         return bool(validate(number))
@@ -85,7 +86,7 @@ def is_valid(number):
         return False
 
 
-def to_iban(number):
+def to_iban(number: str) -> str:
     """Convert the number to an IBAN."""
     from stdnum import iban
     separator = ' ' if ' ' in number else ''
@@ -94,7 +95,7 @@ def to_iban(number):
         number))
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number).zfill(11)
     return '.'.join([

--- a/stdnum/no/mva.py
+++ b/stdnum/no/mva.py
@@ -33,13 +33,14 @@ InvalidChecksum: ...
 >>> format('995525828MVA')
 'NO 995 525 828 MVA'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.no import orgnr
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
@@ -48,7 +49,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid MVA number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -58,7 +59,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid MVA number."""
     try:
         return bool(validate(number))
@@ -66,7 +67,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return 'NO ' + orgnr.format(number[:9]) + ' ' + number[9:]

--- a/stdnum/no/orgnr.py
+++ b/stdnum/no/orgnr.py
@@ -39,24 +39,25 @@ InvalidChecksum: ...
 >>> format('988077917')
 '988 077 917'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (3, 2, 7, 6, 5, 4, 3, 2, 1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid organisation number. This checks the
     length, formatting and check digit."""
     number = compact(number)
@@ -69,7 +70,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid organisation number."""
     try:
         return bool(validate(number))
@@ -77,7 +78,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:3] + ' ' + number[3:6] + ' ' + number[6:]

--- a/stdnum/nz/__init__.py
+++ b/stdnum/nz/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of New Zealand numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.nz import ird as vat  # noqa: F401

--- a/stdnum/nz/bankaccount.py
+++ b/stdnum/nz/bankaccount.py
@@ -41,6 +41,7 @@ InvalidComponent: ...
 >>> format('0102420100194000')
 '01-0242-0100194-000'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -84,21 +85,21 @@ _moduli = {
 }
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
-    number = clean(number).strip().replace(' ', '-').split('-')
-    if len(number) == 4:
+    parts = clean(number).strip().replace(' ', '-').split('-')
+    if len(parts) == 4:
         # zero pad the different sections if they are found
         lengths = (2, 4, 7, 3)
-        return ''.join(n.zfill(l) for n, l in zip(number, lengths))
+        return ''.join(n.zfill(l) for n, l in zip(parts, lengths))
     else:
         # otherwise zero pad the account type
-        number = ''.join(number)
+        number = ''.join(parts)
         return number[:13] + number[13:].zfill(3)
 
 
-def info(number):
+def info(number: str) -> dict[str, str]:
     """Return a dictionary of data about the supplied number. This typically
     returns the name of the bank and branch and a BIC if it is valid."""
     number = compact(number)
@@ -109,7 +110,7 @@ def info(number):
     return info
 
 
-def _calc_checksum(number):
+def _calc_checksum(number: str) -> int:
     # pick the algorithm and parameters
     algorithm = _algorithms.get(number[:2], 'X')
     if algorithm == 'A' and number[6:13] >= '0990000':
@@ -122,7 +123,7 @@ def _calc_checksum(number):
         (w * int(n) for w, n in zip(weights, number))) % mod2
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid bank account number."""
     number = compact(number)
     if not isdigits(number):
@@ -137,7 +138,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid bank account number."""
     try:
         return bool(validate(number))
@@ -145,7 +146,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([

--- a/stdnum/nz/ird.py
+++ b/stdnum/nz/ird.py
@@ -45,12 +45,13 @@ InvalidLength: ...
 >>> format('49098576')
 '49-098-576'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     number = clean(number, ' -').upper().strip()
     if number.startswith('NZ'):
@@ -58,7 +59,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit.
 
     The number passed should not have the check digit included.
@@ -74,7 +75,7 @@ def calc_check_digit(number):
     return str(s)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid IRD number."""
     number = compact(number)
     if len(number) not in (8, 9):
@@ -88,7 +89,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid IRD number."""
     try:
         return bool(validate(number))
@@ -96,7 +97,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:-6], number[-6:-3], number[-3:]])

--- a/stdnum/pe/__init__.py
+++ b/stdnum/pe/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Peruvian numbers."""
+from __future__ import annotations
+
 from stdnum.pe import ruc as vat  # noqa: F401

--- a/stdnum/pe/cui.py
+++ b/stdnum/pe/cui.py
@@ -41,18 +41,19 @@ InvalidChecksum: ...
 >>> to_ruc('10117410-2')
 '10101174102'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip().upper()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the possible check digits for the CUI."""
     number = compact(number)
     weights = (3, 2, 7, 6, 5, 4, 3, 2)
@@ -60,14 +61,14 @@ def calc_check_digits(number):
     return '65432110987'[c] + 'KJIHGFEDCBA'[c]
 
 
-def to_ruc(number):
+def to_ruc(number: str) -> str:
     """Convert the number to a valid RUC."""
     from stdnum.pe import ruc
     number = '10' + compact(number)[:8]
     return number + ruc.calc_check_digit(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid CUI. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid CUI. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/pe/ruc.py
+++ b/stdnum/pe/ruc.py
@@ -39,24 +39,25 @@ InvalidChecksum: ...
 >>> to_dni('10054148289')
 '05414828'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
     return str((11 - sum(w * int(n) for w, n in zip(weights, number)) % 11) % 10)
 
 
-def to_dni(number):
+def to_dni(number: str) -> str:
     """Return the DNI (CUI) part of the number for natural persons."""
     number = validate(number)
     if not number.startswith('10'):
@@ -64,7 +65,7 @@ def to_dni(number):
     return number[2:10]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid RUC. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -79,7 +80,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid RUC. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/pk/cnic.py
+++ b/stdnum/pk/cnic.py
@@ -45,24 +45,27 @@ More Information:
 >>> format('3420108912318')
 '34201-0891231-8'
 """
+from __future__ import annotations
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F'] | None:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if number[-1] in '13579':
         return 'M'
     elif number[-1] in '2468':
         return 'F'
+    return None
 
 
 # Valid Province IDs
@@ -77,13 +80,13 @@ PROVINCES = {
 }
 
 
-def get_province(number):
-    """Get the person's birth gender ('M' or 'F')."""
+def get_province(number: str) -> str | None:
+    """Get the person's province."""
     number = compact(number)
     return PROVINCES.get(number[0])
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CNIC. This checks the length, formatting
     and some digits."""
     number = compact(number)
@@ -98,7 +101,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CNIC."""
     try:
         return bool(validate(number))
@@ -106,7 +109,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[:5], number[5:12], number[12:]))

--- a/stdnum/pl/__init__.py
+++ b/stdnum/pl/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Polish numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.pl import nip as vat  # noqa: F401

--- a/stdnum/pl/nip.py
+++ b/stdnum/pl/nip.py
@@ -31,12 +31,13 @@ InvalidChecksum: ...
 >>> format('PL 8567346215')
 '856-734-62-15'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -45,13 +46,13 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     weights = (6, 5, 7, 2, 3, 4, 5, 6, 7, -1)
     return sum(w * int(n) for w, n in zip(weights, number)) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -64,7 +65,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))
@@ -72,7 +73,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((number[0:3], number[3:6], number[6:8], number[8:]))

--- a/stdnum/pl/pesel.py
+++ b/stdnum/pl/pesel.py
@@ -46,20 +46,22 @@ datetime.date(2002, 1, 13)
 >>> get_gender('02211307589')
 'F'
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     year = int(number[0:2])
@@ -79,7 +81,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if number[9] in '02468':  # even
@@ -88,7 +90,7 @@ def get_gender(number):
         return 'M'
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for organisations. The number passed
     should not have the check digit included."""
     weights = (1, 3, 7, 9, 1, 3, 7, 9, 1, 3)
@@ -96,7 +98,7 @@ def calc_check_digit(number):
     return str((10 - check) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid national identification number. This
     checks the length, formatting and check digit."""
     number = compact(number)
@@ -110,7 +112,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid national identification number."""
     try:
         return bool(validate(number))

--- a/stdnum/pl/regon.py
+++ b/stdnum/pl/regon.py
@@ -49,29 +49,30 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for organisations. The number passed
     should not have the check digit included."""
     if len(number) == 8:
-        weights = (8, 9, 2, 3, 4, 5, 6, 7)
+        weights: tuple[int, ...] = (8, 9, 2, 3, 4, 5, 6, 7)
     else:
         weights = (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8)
     check = sum(w * int(n) for w, n in zip(weights, number))
     return str(check % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid REGON number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -86,7 +87,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid REGON number."""
     try:
         return bool(validate(number))

--- a/stdnum/pt/__init__.py
+++ b/stdnum/pt/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Portuguese numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.pt import nif as vat  # noqa: F401

--- a/stdnum/pt/cc.py
+++ b/stdnum/pt/cc.py
@@ -41,6 +41,7 @@ InvalidChecksum: ...
 >>> format('000000000ZZ4')
 '00000000 0 ZZ4'
 """
+from __future__ import annotations
 
 import re
 
@@ -51,24 +52,27 @@ from stdnum.util import clean
 _cc_re = re.compile(r'^\d*[A-Z0-9]{2}\d$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' ').upper().strip()
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the number."""
     alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-    cutoff = lambda x: x - 9 if x > 9 else x
+
+    def cutoff(x: int) -> int:
+        return x - 9 if x > 9 else x
+
     s = sum(
         cutoff(alphabet.index(n) * 2) if i % 2 == 0 else alphabet.index(n)
         for i, n in enumerate(number[::-1]))
     return str((10 - s) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid cartao de cidadao number."""
     number = compact(number)
     if not _cc_re.match(number):
@@ -78,7 +82,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid cartao de cidadao number."""
     try:
         return bool(validate(number))
@@ -86,7 +90,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join([number[:-4], number[-4], number[-3:]])

--- a/stdnum/pt/nif.py
+++ b/stdnum/pt/nif.py
@@ -31,12 +31,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -45,14 +46,14 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     s = sum((9 - i) * int(n) for i, n in enumerate(number))
     return str((11 - s) % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -65,7 +66,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/py/__init__.py
+++ b/stdnum/py/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Paraguayan numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.py import ruc as vat  # noqa: F401

--- a/stdnum/py/ruc.py
+++ b/stdnum/py/ruc.py
@@ -49,12 +49,13 @@ InvalidLength: ...
 >>> format('800000358')
 '80000035-8'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -63,7 +64,7 @@ def compact(number):
     return clean(number, ' -').upper().strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit.
 
     The number passed should not have the check digit included.
@@ -72,7 +73,7 @@ def calc_check_digit(number):
     return str((-s % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Paraguay RUC number.
 
     This checks the length, formatting and check digit.
@@ -87,7 +88,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Paraguay RUC number."""
     try:
         return bool(validate(number))
@@ -95,7 +96,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:-1], number[-1]])

--- a/stdnum/ro/__init__.py
+++ b/stdnum/ro/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Romanian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ro import cf as vat  # noqa: F401

--- a/stdnum/ro/cf.py
+++ b/stdnum/ro/cf.py
@@ -29,13 +29,14 @@ The Romanian CF is used for VAT purposes and can be from 2 to 10 digits long.
 >>> validate('1630615123457')  # CNP
 '1630615123457'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.ro import cnp, cui
 from stdnum.util import clean
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
@@ -45,7 +46,7 @@ def compact(number):
 calc_check_digit = cui.calc_check_digit
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -62,7 +63,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ro/cnp.py
+++ b/stdnum/ro/cnp.py
@@ -49,6 +49,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import datetime
 
@@ -111,13 +112,13 @@ _COUNTIES = {
 }
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for personal codes."""
     # note that this algorithm has not been confirmed by an independent source
     weights = (2, 7, 9, 1, 4, 6, 3, 5, 8, 2, 7, 9)
@@ -125,7 +126,7 @@ def calc_check_digit(number):
     return '1' if check == 10 else str(check)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the birth date."""
     number = compact(number)
     centuries = {
@@ -140,7 +141,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_county(number):
+def get_county(number: str) -> str:
     """Get the county name from the number"""
     try:
         return _COUNTIES[compact(number)[7:9]]
@@ -148,7 +149,7 @@ def get_county(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -169,7 +170,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ro/cui.py
+++ b/stdnum/ro/cui.py
@@ -42,12 +42,13 @@ InvalidChecksum: ...
 >>> validate('RO 185 472 90')  # the RO prefix is ignored
 '18547290'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -56,7 +57,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (7, 5, 3, 2, 1, 7, 5, 3, 2)
     number = number.zfill(9)
@@ -64,7 +65,7 @@ def calc_check_digit(number):
     return str(check % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid CUI or CIF number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -77,7 +78,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid CUI or CIF number."""
     try:
         return bool(validate(number))

--- a/stdnum/ro/onrc.py
+++ b/stdnum/ro/onrc.py
@@ -34,6 +34,7 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import datetime
 import re
@@ -56,7 +57,7 @@ _onrc_re = re.compile(r'^[A-Z][0-9]+/[0-9]+/[0-9]+$')
 _counties = set(list(range(1, 41)) + [51, 52])
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = _cleanup_re.sub('/', clean(number).upper().strip())
@@ -73,7 +74,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ONRC."""
     number = compact(number)
     if not _onrc_re.match(number):
@@ -92,7 +93,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ONRC."""
     try:
         return bool(validate(number))

--- a/stdnum/rs/__init__.py
+++ b/stdnum/rs/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Serbian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.rs import pib as vat  # noqa: F401

--- a/stdnum/rs/pib.py
+++ b/stdnum/rs/pib.py
@@ -30,19 +30,20 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.iso7064 import mod_11_10
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -54,7 +55,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ru/__init__.py
+++ b/stdnum/ru/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Russian numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ru import inn as vat  # noqa: F401

--- a/stdnum/ru/inn.py
+++ b/stdnum/ru/inn.py
@@ -37,33 +37,34 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_company_check_digit(number):
+def calc_company_check_digit(number: str) -> str:
     """Calculate the check digit for the 10-digit ИНН for organisations."""
     weights = (2, 4, 10, 3, 5, 9, 4, 6, 8)
     return str(sum(w * int(n) for w, n in zip(weights, number)) % 11 % 10)
 
 
-def calc_personal_check_digits(number):
+def calc_personal_check_digits(number: str) -> str:
     """Calculate the check digits for the 12-digit personal ИНН."""
-    weights = (7, 2, 4, 10, 3, 5, 9, 4, 6, 8)
+    weights: tuple[int, ...] = (7, 2, 4, 10, 3, 5, 9, 4, 6, 8)
     d1 = str(sum(w * int(n) for w, n in zip(weights, number)) % 11 % 10)
     weights = (3, 7, 2, 4, 10, 3, 5, 9, 4, 6, 8)
     d2 = str(sum(w * int(n) for w, n in zip(weights, number[:10] + d1)) % 11 % 10)
     return d1 + d2
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ИНН. This checks the length, formatting
     and check digit."""
     number = compact(number)
@@ -81,7 +82,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ИНН."""
     try:
         return bool(validate(number))

--- a/stdnum/ru/ogrn.py
+++ b/stdnum/ru/ogrn.py
@@ -43,18 +43,19 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ')
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the control digit of the OGRN based on its length."""
     if len(number) == 13:
         return str(int(number[:-1]) % 11 % 10)
@@ -62,7 +63,7 @@ def calc_check_digit(number):
         return str(int(number[:-1]) % 13)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Determine if the given number is a valid OGRN."""
     number = compact(number)
     if not isdigits(number):
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid OGRN."""
     try:
         return bool(validate(number))

--- a/stdnum/se/__init__.py
+++ b/stdnum/se/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Swedish numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.se import personnummer as personalid  # noqa: F401

--- a/stdnum/se/orgnr.py
+++ b/stdnum/se/orgnr.py
@@ -35,19 +35,20 @@ InvalidChecksum: ...
 >>> format('123456-7897')
 '123456-7897'
 """
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -.').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid organisation number. This checks
     the length, formatting and check digit."""
     number = compact(number)
@@ -58,7 +59,7 @@ def validate(number):
     return luhn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid organisation number"""
     try:
         return bool(validate(number))
@@ -66,7 +67,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number[:6] + '-' + number[6:]

--- a/stdnum/se/personnummer.py
+++ b/stdnum/se/personnummer.py
@@ -44,15 +44,17 @@ datetime.date(1981, 12, 28)
 >>> format('8803200016')
 '880320-0016'
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' :')
@@ -61,7 +63,7 @@ def compact(number):
     return number[:-5].replace('-', '').replace('+', '') + number[-5:]
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Determine the birth date from the number.
 
     For people aged 100 and up, the minus/dash in the personnummer is changed to a plus
@@ -90,7 +92,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if int(number[-2]) % 2:
@@ -99,7 +101,7 @@ def get_gender(number):
         return 'F'
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid identity number."""
     number = compact(number)
     if len(number) not in (11, 13):
@@ -112,7 +114,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid identity number."""
     try:
         return bool(validate(number))
@@ -120,6 +122,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/se/postnummer.py
+++ b/stdnum/se/postnummer.py
@@ -38,12 +38,13 @@ InvalidLength: ...
 >>> format('11418')
 '114 18'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -52,7 +53,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is in the correct format. This currently does not
     check whether the code corresponds to a real address."""
     number = compact(number)
@@ -63,7 +64,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid postal code."""
     try:
         return bool(validate(number))
@@ -71,7 +72,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '%s %s' % (number[:3], number[3:])

--- a/stdnum/se/vat.py
+++ b/stdnum/se/vat.py
@@ -31,13 +31,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.se import orgnr
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -.').upper().strip()
@@ -46,7 +47,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -56,7 +57,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/sg/__init__.py
+++ b/stdnum/sg/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Singapore numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.sg import uen as vat  # noqa: F401

--- a/stdnum/sg/uen.py
+++ b/stdnum/sg/uen.py
@@ -59,6 +59,7 @@ InvalidLength: ...
 # There are some references to special 10-digit (or 7-digit) numbers that
 # start with an F for foreign companies but it is unclear whether this is
 # still current and not even examples of these numbers could be found.
+from __future__ import annotations
 
 from datetime import datetime
 
@@ -74,7 +75,7 @@ OTHER_UEN_ENTITY_TYPES = (
 )
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This converts to uppercase and removes surrounding whitespace. It
@@ -84,14 +85,14 @@ def compact(number):
     return clean(number).upper().strip()
 
 
-def calc_business_check_digit(number):
+def calc_business_check_digit(number: str) -> str:
     """Calculate the check digit for the Business (ROB) number."""
     number = compact(number)
     weights = (10, 4, 9, 3, 8, 2, 7, 1)
     return 'XMKECAWLJDB'[sum(int(n) * w for n, w in zip(number, weights)) % 11]
 
 
-def _validate_business(number):
+def _validate_business(number: str) -> str:
     """Perform validation on UEN - Business (ROB) numbers."""
     if not isdigits(number[:-1]):
         raise InvalidFormat()
@@ -102,14 +103,14 @@ def _validate_business(number):
     return number
 
 
-def calc_local_company_check_digit(number):
+def calc_local_company_check_digit(number: str) -> str:
     """Calculate the check digit for the Local Company (ROC) number."""
     number = compact(number)
     weights = (10, 8, 6, 4, 9, 7, 5, 3, 1)
     return 'ZKCMDNERGWH'[sum(int(n) * w for n, w in zip(number, weights)) % 11]
 
 
-def _validate_local_company(number):
+def _validate_local_company(number: str) -> str:
     """Perform validation on UEN - Local Company (ROC) numbers."""
     if not isdigits(number[:-1]):
         raise InvalidFormat()
@@ -121,7 +122,7 @@ def _validate_local_company(number):
     return number
 
 
-def calc_other_check_digit(number):
+def calc_other_check_digit(number: str) -> str:
     """Calculate the check digit for the other entities number."""
     number = compact(number)
     alphabet = 'ABCDEFGHJKLMNPQRSTUVWX0123456789'
@@ -129,7 +130,7 @@ def calc_other_check_digit(number):
     return alphabet[(sum(alphabet.index(n) * w for n, w in zip(number, weights)) - 5) % 11]
 
 
-def _validate_other(number):
+def _validate_other(number: str) -> str:
     """Perform validation on other UEN numbers."""
     if number[0] not in ('R', 'S', 'T'):
         raise InvalidComponent()
@@ -147,7 +148,7 @@ def _validate_other(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Singapore UEN number."""
     number = compact(number)
     if len(number) not in (9, 10):
@@ -159,7 +160,7 @@ def validate(number):
     return _validate_other(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Singapore UEN number."""
     try:
         return bool(validate(number))
@@ -167,6 +168,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/si/__init__.py
+++ b/stdnum/si/__init__.py
@@ -20,6 +20,7 @@
 # 02110-1301 USA
 
 """Collection of Slovenian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.si import ddv as vat  # noqa: F401

--- a/stdnum/si/ddv.py
+++ b/stdnum/si/ddv.py
@@ -31,12 +31,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -45,7 +46,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     check = (11 - sum((8 - i) * int(n) for i, n in enumerate(number)) % 11)
@@ -53,7 +54,7 @@ def calc_check_digit(number):
     return '0' if check == 10 else str(check)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -66,7 +67,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/si/emso.py
+++ b/stdnum/si/emso.py
@@ -40,27 +40,29 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
     total = sum(int(n) * w for n, w in zip(number, weights))
     return str(-total % 11 % 10)
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Return date of birth from valid EMŠO."""
     number = compact(number)
     day = int(number[:2])
@@ -76,7 +78,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the person's birth gender ('M' or 'F')."""
     number = compact(number)
     if int(number[9:12]) < 500:
@@ -85,12 +87,12 @@ def get_gender(number):
         return 'F'
 
 
-def get_region(number):
+def get_region(number: str) -> str:
     """Return (political) region from valid EMŠO."""
     return number[7:9]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid EMŠO number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -104,7 +106,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid ID. This checks the length,
     formatting and check digit."""
     try:
@@ -113,6 +115,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/si/maticna.py
+++ b/stdnum/si/maticna.py
@@ -42,6 +42,7 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -49,7 +50,7 @@ from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, '. ').strip().upper()
@@ -58,7 +59,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (7, 6, 5, 4, 3, 2)
     total = sum(int(n) * w for n, w in zip(number, weights))
@@ -68,7 +69,7 @@ def calc_check_digit(number):
     return str(remainder % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Corporate Registration number. This
     checks the length and check digit."""
     number = compact(number)
@@ -83,7 +84,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if provided is valid ID. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/sk/__init__.py
+++ b/stdnum/sk/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Slovak numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.sk import dph as vat  # noqa: F401

--- a/stdnum/sk/dph.py
+++ b/stdnum/sk/dph.py
@@ -30,13 +30,14 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.sk import rc
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     number = clean(number, ' -').upper().strip()
@@ -45,12 +46,12 @@ def compact(number):
     return number
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the checksum."""
     return int(number) % 11
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -68,7 +69,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/sk/rc.py
+++ b/stdnum/sk/rc.py
@@ -49,6 +49,8 @@ InvalidLength: ...
 
 # since this number is essentially the same as the Czech counterpart
 # (until 1993 the Czech Republic and Slovakia were one country)
+from __future__ import annotations
+
 from stdnum.cz.rc import compact, format, is_valid, validate
 
 

--- a/stdnum/sm/__init__.py
+++ b/stdnum/sm/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of San Marino numbers."""
+from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.sm import coe as vat  # noqa: F401

--- a/stdnum/sm/coe.py
+++ b/stdnum/sm/coe.py
@@ -38,6 +38,7 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -51,13 +52,13 @@ _lownumbers = set((
     87, 88, 91, 92, 94, 95, 96, 97, 99))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips
     surrounding whitespace and separation dash."""
     return clean(number, '.').strip().lstrip('0')
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid COE. This checks the length and
     formatting."""
     number = compact(number)
@@ -70,7 +71,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid COE."""
     try:
         return bool(validate(number))

--- a/stdnum/sv/__init__.py
+++ b/stdnum/sv/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of El Salvador numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.sv import nit as vat  # noqa: F401

--- a/stdnum/sv/nit.py
+++ b/stdnum/sv/nit.py
@@ -60,12 +60,13 @@ InvalidLength: ...
 >>> format('06140507071048')
 '0614-050707-104-8'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -77,7 +78,7 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     # Old NIT
     if number[10:13] <= '100':
@@ -90,7 +91,7 @@ def calc_check_digit(number):
     return str((-total % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid El Salvador NIT number.
 
     This checks the length, formatting and check digit.
@@ -107,7 +108,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid El Salvador NIT number."""
     try:
         return bool(validate(number))
@@ -115,7 +116,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:4], number[4:-4], number[-4:-1], number[-1]])

--- a/stdnum/th/moa.py
+++ b/stdnum/th/moa.py
@@ -44,6 +44,7 @@ InvalidChecksum: ...
 >>> format('0993000133978')
 '0-99-3-000-13397-8'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.th import pin
@@ -57,13 +58,13 @@ __all__ = ['compact', 'calc_check_digit', 'validate', 'is_valid', 'format']
 calc_check_digit = pin.calc_check_digit
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid MOA Number. This checks the length,
     formatting, component and check digit."""
     number = compact(number)
@@ -78,7 +79,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the number is valid."""
     try:
         return bool(validate(number))
@@ -86,7 +87,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((

--- a/stdnum/th/pin.py
+++ b/stdnum/th/pin.py
@@ -43,24 +43,25 @@ InvalidChecksum: ...
 >>> format('7100600445635')
 '7-1006-00445-63-5'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     s = sum((2 - i) * int(n) for i, n in enumerate(number[:12])) % 11
     return str((1 - s) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid PIN. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -75,7 +76,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the number is valid."""
     try:
         return bool(validate(number))
@@ -83,7 +84,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join((

--- a/stdnum/th/tin.py
+++ b/stdnum/th/tin.py
@@ -42,6 +42,7 @@ InvalidFormat: ...
 >>> format('0993000133978')
 '0-99-3-000-13397-8'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.th import moa, pin
@@ -51,13 +52,13 @@ from stdnum.util import clean
 _tin_modules = (moa, pin)
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').strip()
 
 
-def tin_type(number):
+def tin_type(number: str) -> str | None:
     """Return a TIN type which this number is valid."""
     number = compact(number)
     for mod in _tin_modules:
@@ -67,19 +68,19 @@ def tin_type(number):
     return None
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid TIN. This searches for the proper
     sub-type and validates using that."""
     for mod in _tin_modules:
         try:
-            return mod.validate(number)
+            return mod.validate(number)  # type: ignore[no-any-return]
         except ValidationError:
             pass  # try next module
     # fallback
     raise InvalidFormat()
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check whether the number is valid."""
     try:
         return bool(validate(number))
@@ -87,9 +88,9 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     for mod in _tin_modules:
         if mod.is_valid(number):
-            return mod.format(number)
+            return mod.format(number)  # type: ignore[no-any-return]
     return number

--- a/stdnum/tn/__init__.py
+++ b/stdnum/tn/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Tunisian numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.tn import mf as vat  # noqa: F401

--- a/stdnum/tn/mf.py
+++ b/stdnum/tn/mf.py
@@ -62,6 +62,7 @@ InvalidFormat: ...
 >>> format('1496298 T P N 000')
 '1496298/T/P/N/000'
 """
+from __future__ import annotations
 
 import re
 
@@ -76,7 +77,7 @@ _VALID_TVA_CODES = ('A', 'P', 'B', 'D', 'N')
 _VALID_CATEGORY_CODES = ('M', 'P', 'C', 'N', 'E')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators, removes surrounding
@@ -90,7 +91,7 @@ def compact(number):
     return number
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Tunisia MF number.
 
     This checks the length and formatting.
@@ -115,7 +116,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Tunisia MF number."""
     try:
         return bool(validate(number))
@@ -123,7 +124,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     result = compact(number)
     if len(result) == 8:

--- a/stdnum/tr/__init__.py
+++ b/stdnum/tr/__init__.py
@@ -19,4 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Turkish numbers."""
+from __future__ import annotations
+
 from stdnum.tr import vkn as vat  # noqa: F401

--- a/stdnum/tr/tckimlik.py
+++ b/stdnum/tr/tckimlik.py
@@ -44,6 +44,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, get_soap_client, isdigits
@@ -53,13 +54,13 @@ tckimlik_wsdl = 'https://tckimlik.nvi.gov.tr/Service/KPSPublic.asmx?WSDL'
 """The WSDL URL of the T.C. Kimlik validation service."""
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number).strip()
 
 
-def calc_check_digits(number):
+def calc_check_digits(number: str) -> str:
     """Calculate the check digits for the specified number. The number
     passed should not have the check digit included."""
     check1 = (10 - sum((3, 1)[i % 2] * int(n)
@@ -68,7 +69,7 @@ def calc_check_digits(number):
     return '%d%d' % (check1, check2)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid T.C. Kimlik number. This checks the
     length and check digits."""
     number = compact(number)
@@ -81,7 +82,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid T.C. Kimlik number."""
     try:
         return bool(validate(number))
@@ -89,7 +90,7 @@ def is_valid(number):
         return False
 
 
-def check_kps(number, name, surname, birth_year, timeout=30, verify=True):  # pragma: no cover
+def check_kps(number, name, surname, birth_year, timeout=30, verify=True):  # type: ignore # pragma: no cover
     """Use the T.C. Kimlik validation service to check the provided number.
 
     Query the online T.C. Kimlik validation service run by the Directorate

--- a/stdnum/tr/vkn.py
+++ b/stdnum/tr/vkn.py
@@ -39,18 +39,19 @@ Traceback (most recent call last):
     ...
 InvalidLength: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number).strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the specified number."""
     s = 0
     for i, n in enumerate(reversed(number[:9]), 1):
@@ -61,7 +62,7 @@ def calc_check_digit(number):
     return str((10 - s) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Vergi Kimlik Numarası. This checks the
     length and check digits."""
     number = compact(number)
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Vergi Kimlik Numarası. This checks the
     length and check digits."""
     try:

--- a/stdnum/tw/__init__.py
+++ b/stdnum/tw/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Taiwanese numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.tw import ubn as vat  # noqa: F401

--- a/stdnum/tw/ubn.py
+++ b/stdnum/tw/ubn.py
@@ -42,12 +42,13 @@ InvalidLength: ...
 >>> format(' 0050150 3 ')
 '00501503'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -56,7 +57,7 @@ def compact(number):
     return clean(number, ' -').strip()
 
 
-def calc_checksum(number):
+def calc_checksum(number: str) -> int:
     """Calculate the checksum over the number."""
     # convert to numeric first, then sum individual digits
     weights = (1, 2, 1, 2, 1, 2, 4, 1)
@@ -64,7 +65,7 @@ def calc_checksum(number):
     return sum(int(n) for n in number) % 10
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Taiwan UBN number.
 
     This checks the length, formatting and check digit.
@@ -80,7 +81,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Taiwan UBN number."""
     try:
         return bool(validate(number))
@@ -88,6 +89,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/ua/edrpou.py
+++ b/stdnum/ua/edrpou.py
@@ -43,19 +43,20 @@ InvalidLength: ...
 >>> format(' 32855961 ')
 '32855961'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for number."""
-    weights = (1, 2, 3, 4, 5, 6, 7)
+    weights: tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7)
     if number[0] in '345':
         weights = (7, 1, 2, 3, 4, 5, 6)
     total = sum(w * int(n) for w, n in zip(weights, number))
@@ -67,7 +68,7 @@ def calc_check_digit(number):
     return str(total % 11 % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Ukraine EDRPOU (ЄДРПОУ) number.
 
     This checks the length, formatting and check digit.
@@ -82,7 +83,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Ukraine EDRPOU (ЄДРПОУ) number."""
     try:
         return bool(validate(number))
@@ -90,6 +91,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/ua/rntrc.py
+++ b/stdnum/ua/rntrc.py
@@ -42,24 +42,25 @@ InvalidLength: ...
 >>> format(' 25 30 41 40 71 ')
 '2530414071'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     return clean(number, ' ').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for number."""
     weights = (-1, 5, 7, 9, 4, 6, 10, 5, 7)
     total = sum(w * int(n) for w, n in zip(weights, number))
     return str((total % 11) % 10)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Ukraine RNTRC (РНОКПП) number.
 
     This checks the length, formatting and check digit.
@@ -74,7 +75,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Ukraine RNTRC (РНОКПП) number."""
     try:
         return bool(validate(number))
@@ -82,6 +83,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/stdnum/us/atin.py
+++ b/stdnum/us/atin.py
@@ -34,6 +34,7 @@ InvalidFormat: ...
 >>> format('123')  # unknown formatting is left alone
 '123'
 """
+from __future__ import annotations
 
 import re
 
@@ -45,13 +46,13 @@ from stdnum.util import clean
 _atin_re = re.compile(r'^[0-9]{3}-?[0-9]{2}-?[0-9]{4}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ATIN. This checks the length and
     formatting if it is present."""
     match = _atin_re.search(clean(number, '').strip())
@@ -61,7 +62,7 @@ def validate(number):
     return compact(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ATIN."""
     try:
         return bool(validate(number))
@@ -69,7 +70,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     if len(number) == 9:
         number = number[:3] + '-' + number[3:5] + '-' + number[5:]

--- a/stdnum/us/ein.py
+++ b/stdnum/us/ein.py
@@ -41,6 +41,7 @@ InvalidComponent: ...
 >>> format('123')  # unknown formatting is left alone
 '123'
 """
+from __future__ import annotations
 
 import re
 
@@ -52,13 +53,13 @@ from stdnum.util import clean
 _ein_re = re.compile(r'^(?P<area>[0-9]{2})-?(?P<group>[0-9]{7})$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def get_campus(number):
+def get_campus(number: str) -> str:
     """Determine the Campus or other location that issued the EIN."""
     from stdnum import numdb
     number = compact(number)
@@ -68,7 +69,7 @@ def get_campus(number):
     return results['campus']
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid EIN. This checks the length, groups and
     formatting if it is present."""
     match = _ein_re.search(clean(number, '').strip())
@@ -78,7 +79,7 @@ def validate(number):
     return compact(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid EIN."""
     try:
         return bool(validate(number))
@@ -86,7 +87,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     if len(number) == 9:
         number = number[:2] + '-' + number[2:]

--- a/stdnum/us/itin.py
+++ b/stdnum/us/itin.py
@@ -48,6 +48,7 @@ InvalidComponent: ...
 >>> format('123')  # unknown formatting is left alone
 '123'
 """
+from __future__ import annotations
 
 import re
 
@@ -63,13 +64,13 @@ _itin_re = re.compile(r'^(?P<area>[0-9]{3})-?(?P<group>[0-9]{2})-?[0-9]{4}$')
 _allowed_groups = set((str(x) for x in range(70, 100) if x not in (89, 93)))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid ITIN. This checks the length, groups
     and formatting if it is present."""
     match = _itin_re.search(clean(number, '').strip())
@@ -82,7 +83,7 @@ def validate(number):
     return compact(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ITIN."""
     try:
         return bool(validate(number))
@@ -90,7 +91,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     if len(number) == 9:
         number = number[:3] + '-' + number[3:5] + '-' + number[5:]

--- a/stdnum/us/ptin.py
+++ b/stdnum/us/ptin.py
@@ -32,6 +32,7 @@ Traceback (most recent call last):
     ...
 InvalidFormat: ...
 """
+from __future__ import annotations
 
 import re
 
@@ -43,13 +44,13 @@ from stdnum.util import clean
 _ptin_re = re.compile(r'^P[0-9]{8}$')
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid PTIN. This checks the length, groups
     and formatting if it is present."""
     number = compact(number).upper()
@@ -59,7 +60,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid ATIN."""
     try:
         return bool(validate(number))

--- a/stdnum/us/rtn.py
+++ b/stdnum/us/rtn.py
@@ -41,19 +41,20 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ..
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any surrounding whitespace."""
     number = clean(number).strip()
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have the
     check digit included."""
     digits = [int(c) for c in number]
@@ -65,7 +66,7 @@ def calc_check_digit(number):
     return str(checksum)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid routing number. This checks the length
     and check digit."""
     number = compact(number)
@@ -78,7 +79,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid RTN."""
     try:
         return bool(validate(number))

--- a/stdnum/us/ssn.py
+++ b/stdnum/us/ssn.py
@@ -59,6 +59,7 @@ InvalidComponent: ...
 >>> format('111223333')
 '111-22-3333'
 """
+from __future__ import annotations
 
 import re
 
@@ -74,13 +75,13 @@ _ssn_re = re.compile(
 _ssn_blacklist = set(('078-05-1120', '457-55-5462', '219-09-9999'))
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid SSN. This checks the length, groups and
     formatting if it is present."""
     match = _ssn_re.search(clean(number, '').strip())
@@ -100,7 +101,7 @@ def validate(number):
     return compact(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid SSN."""
     try:
         return bool(validate(number))
@@ -108,7 +109,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     if len(number) == 9:
         number = number[:3] + '-' + number[3:5] + '-' + number[5:]

--- a/stdnum/us/tin.py
+++ b/stdnum/us/tin.py
@@ -47,6 +47,7 @@ InvalidFormat: ...
 >>> format('123-456')  # invalid numbers are not reformatted
 '123-456'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.us import atin, ein, itin, ptin, ssn
@@ -56,25 +57,25 @@ from stdnum.util import clean
 _tin_modules = (ssn, itin, ein, ptin, atin)
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, '-').strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid TIN. This searches for the proper
     sub-type and validates using that."""
     for mod in _tin_modules:
         try:
-            return mod.validate(number)
+            return mod.validate(number)  # type: ignore[no-any-return]
         except ValidationError:
             pass  # try next module
     # fallback
     raise InvalidFormat()
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid TIN."""
     try:
         return bool(validate(number))
@@ -82,7 +83,7 @@ def is_valid(number):
         return False
 
 
-def guess_type(number):
+def guess_type(number: str) -> list[str]:
     """Return a list of possible TIN types for which this number is
     valid.."""
     return [mod.__name__.rsplit('.', 1)[-1]
@@ -90,9 +91,9 @@ def guess_type(number):
             if mod.is_valid(number)]
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     for mod in _tin_modules:
         if mod.is_valid(number) and hasattr(mod, 'format'):
-            return mod.format(number)
+            return mod.format(number)  # type: ignore[no-any-return]
     return number

--- a/stdnum/uy/__init__.py
+++ b/stdnum/uy/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Uruguayan numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.uy import rut as vat  # noqa: F401

--- a/stdnum/uy/rut.py
+++ b/stdnum/uy/rut.py
@@ -47,6 +47,7 @@ InvalidLength: ...
 >>> format('211003420017')
 '21-100342-001-7'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
@@ -58,7 +59,7 @@ from stdnum.util import clean, isdigits
 # https://servicios.dgi.gub.uy/ServiciosEnLinea/ampliar/servicios-automatizados
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -70,14 +71,14 @@ def compact(number):
     return number
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
     total = sum(int(n) * w for w, n in zip(weights, number))
     return str(-total % 11)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Uruguay RUT number.
 
     This checks the length, formatting and check digit.
@@ -98,7 +99,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Uruguay RUT number."""
     try:
         return bool(validate(number))
@@ -106,7 +107,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return '-'.join([number[:2], number[2:-4], number[-4:-1], number[-1]])

--- a/stdnum/vatin.py
+++ b/stdnum/vatin.py
@@ -23,7 +23,7 @@
 The number VAT identification number (VATIN) is an identifier used in many
 countries. It starts with an ISO 3166-1 alpha-2 (2 letters) country code
 (except for Greece, which uses EL, instead of GR) and is followed by the
-country-specific the identifier.
+country-specific identifier.
 
 This module supports all VAT numbers that are supported in python-stdnum.
 
@@ -46,9 +46,11 @@ Traceback (most recent call last):
     ...
 InvalidComponent: ...
 """
+from __future__ import annotations
 
 import re
 
+from stdnum import _typing as t
 from stdnum.exceptions import *
 from stdnum.util import clean, get_cc_module
 
@@ -57,7 +59,7 @@ from stdnum.util import clean, get_cc_module
 _country_modules = dict()
 
 
-def _get_cc_module(cc):
+def _get_cc_module(cc: str) -> t.NumberValidationModule:
     """Get the VAT number module based on the country code."""
     # Greece uses a "wrong" country code, special case for Northern Ireland
     cc = cc.lower().replace('el', 'gr').replace('xi', 'gb')
@@ -65,12 +67,14 @@ def _get_cc_module(cc):
         raise InvalidFormat()
     if cc not in _country_modules:
         _country_modules[cc] = get_cc_module(cc, 'vat')
-    if not _country_modules[cc]:
+
+    module = _country_modules[cc]
+    if module is None:
         raise InvalidComponent()  # unknown/unsupported country code
-    return _country_modules[cc]
+    return module
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation."""
     number = clean(number).strip()
     module = _get_cc_module(number[:2])
@@ -80,7 +84,7 @@ def compact(number):
         return module.compact(number)
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid VAT number.
 
     This performs the country-specific check for the number.
@@ -93,7 +97,7 @@ def validate(number):
         return module.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid VAT number."""
     try:
         return bool(validate(number))

--- a/stdnum/ve/__init__.py
+++ b/stdnum/ve/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Venezuelan numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.ve import rif as vat  # noqa: F401

--- a/stdnum/ve/rif.py
+++ b/stdnum/ve/rif.py
@@ -32,12 +32,13 @@ Traceback (most recent call last):
     ...
 InvalidChecksum: ...
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
     number of any valid separators and removes surrounding whitespace."""
     return clean(number, ' -').upper().strip()
@@ -54,7 +55,7 @@ _company_types = {
 }
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit for the RIF."""
     number = compact(number)
     weights = (3, 2, 7, 6, 5, 4, 3, 2)
@@ -63,7 +64,7 @@ def calc_check_digit(number):
     return '00987654321'[c % 11]
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided is a valid RIF. This checks the length,
     formatting and check digit."""
     number = compact(number)
@@ -78,7 +79,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided is a valid RIF. This checks the length,
     formatting and check digit."""
     try:

--- a/stdnum/verhoeff.py
+++ b/stdnum/verhoeff.py
@@ -44,6 +44,7 @@ InvalidChecksum: ...
 >>> validate('12340')
 '12340'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 
@@ -74,19 +75,16 @@ _permutation_table = (
     (7, 0, 4, 6, 9, 1, 3, 2, 5, 8))
 
 
-def checksum(number):
+def checksum(number: str) -> int:
     """Calculate the Verhoeff checksum over the provided number. The checksum
     is returned as an int. Valid numbers should have a checksum of 0."""
-    # transform number list
-    number = tuple(int(n) for n in reversed(str(number)))
-    # calculate checksum
     check = 0
-    for i, n in enumerate(number):
+    for i, n in enumerate(int(n) for n in reversed(str(number))):
         check = _multiplication_table[check][_permutation_table[i % 8][n]]
     return check
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number provided passes the Verhoeff checksum."""
     if not bool(number):
         raise InvalidFormat()
@@ -99,7 +97,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number provided passes the Verhoeff checksum."""
     try:
         return bool(validate(number))
@@ -107,7 +105,7 @@ def is_valid(number):
         return False
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the extra digit that should be appended to the number to
     make it a valid number."""
     return str(_multiplication_table[checksum(str(number) + '0')].index(0))

--- a/stdnum/vn/__init__.py
+++ b/stdnum/vn/__init__.py
@@ -19,6 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Vietnam numbers."""
+from __future__ import annotations
 
 # provide aliases
 from stdnum.vn import mst as vat  # noqa: F401

--- a/stdnum/vn/mst.py
+++ b/stdnum/vn/mst.py
@@ -60,12 +60,13 @@ InvalidChecksum: ...
 >>> format('0312 68 78 78 - 001')
 '0312687878-001'
 """
+from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -74,14 +75,14 @@ def compact(number):
     return clean(number, ' -.').strip()
 
 
-def calc_check_digit(number):
+def calc_check_digit(number: str) -> str:
     """Calculate the check digit."""
     weights = (31, 29, 23, 19, 17, 13, 7, 5, 3)
     total = sum(w * int(n) for w, n in zip(weights, number))
     return str(10 - (total % 11))
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid Vietnam MST number.
 
     This checks the length, formatting and check digit.
@@ -100,7 +101,7 @@ def validate(number):
     return number
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid Vietnam MST number."""
     try:
         return bool(validate(number))
@@ -108,7 +109,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return number if len(number) == 10 else '-'.join([number[:10], number[10:]])

--- a/stdnum/za/idnr.py
+++ b/stdnum/za/idnr.py
@@ -48,15 +48,17 @@ datetime.date(1975, 3, 30)
 >>> format('750330 5044089')
 '750330 5044 08 9'
 """
+from __future__ import annotations
 
 import datetime
 
+from stdnum import _typing as t
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -65,7 +67,7 @@ def compact(number):
     return clean(number, ' ')
 
 
-def get_birth_date(number):
+def get_birth_date(number: str) -> datetime.date:
     """Split the date parts from the number and return the date of birth.
 
     Since the number only uses two digits for the year, the century may be
@@ -84,7 +86,7 @@ def get_birth_date(number):
         raise InvalidComponent()
 
 
-def get_gender(number):
+def get_gender(number: str) -> t.Literal['M', 'F']:
     """Get the gender (M/F) from the person's ID number."""
     number = compact(number)
     if number[6] in '01234':
@@ -93,7 +95,7 @@ def get_gender(number):
         return 'M'
 
 
-def get_citizenship(number):
+def get_citizenship(number: str) -> t.Literal['citizen', 'resident']:
     """Get the citizenship status (citizen/resident) from the ID number."""
     number = compact(number)
     if number[10] == '0':
@@ -104,7 +106,7 @@ def get_citizenship(number):
         raise InvalidComponent()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid South African ID number.
 
     This checks the length, formatting and check digit.
@@ -119,7 +121,7 @@ def validate(number):
     return luhn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid South African ID number."""
     try:
         return bool(validate(number))
@@ -127,7 +129,7 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     number = compact(number)
     return ' '.join((number[:6], number[6:10], number[10:12], number[12:]))

--- a/stdnum/za/tin.py
+++ b/stdnum/za/tin.py
@@ -42,13 +42,14 @@ InvalidLength: ...
 >>> format('084308984-8')
 '0843089848'
 """  # noqa: E501
+from __future__ import annotations
 
 from stdnum import luhn
 from stdnum.exceptions import *
 from stdnum.util import clean, isdigits
 
 
-def compact(number):
+def compact(number: str) -> str:
     """Convert the number to the minimal representation.
 
     This strips the number of any valid separators and removes surrounding
@@ -57,7 +58,7 @@ def compact(number):
     return clean(number, ' -/').upper().strip()
 
 
-def validate(number):
+def validate(number: str) -> str:
     """Check if the number is a valid South Africa Tax Reference Number.
 
     This checks the length, formatting and check digit.
@@ -72,7 +73,7 @@ def validate(number):
     return luhn.validate(number)
 
 
-def is_valid(number):
+def is_valid(number: str) -> bool:
     """Check if the number is a valid South Africa Tax Reference Number."""
     try:
         return bool(validate(number))
@@ -80,6 +81,6 @@ def is_valid(number):
         return False
 
 
-def format(number):
+def format(number: str) -> str:
     """Reformat the number to the standard presentation format."""
     return compact(number)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312,313,py3},flake8,docs,headers
+envlist = py{37,38,39,310,311,312,313,py3},flake8,docs,headers
 skip_missing_interpreters = true
 
 [testenv]
@@ -29,6 +29,18 @@ deps = flake8<6.0
 commands = flake8 .
 setenv=
     PYTHONWARNINGS=ignore
+
+[testenv:mypy]
+skip_install = true
+deps = mypy
+       types-requests
+       zeep
+commands =
+    mypy -p stdnum --python-version 3.9
+    mypy -p stdnum --python-version 3.10
+    mypy -p stdnum --python-version 3.11
+    mypy -p stdnum --python-version 3.12
+    mypy -p stdnum --python-version 3.13
 
 [testenv:docs]
 use_develop = true


### PR DESCRIPTION
Closes #433

This adds inline type hints to the project. While trying to keep runtime impact to the absolute minimum, while still allowing for runtime introspection of type hints.

As a side effect this puts a hard limit of Python 3.7 as our minimum version, since older versions than 3.5 did not have support for any inline annotations at all and older versions than 3.7 did not have support for `from __future__ import annotations`. The experience of maintaining type hints is much worse without the latter, so it seems like a reasonable trade-off to me, given that 3.6 has been EOL since 2022.

Otherwise it would make more sense to ship third party stubs.

Type hints are only guaranteed to be correct for Python 3.9+, which also seems like a reasonable trade-off, since current versions of type checkers don't support older versions than that anyways.

If you want to be able to introspect type hints, `typing_extensions` needs to be installed, which is once again reasonable, given that every major runtime typing library depends on `typing_extensions` and static type checkers have access to it via typeshed. Also for runtime introspection, the minimum Python version is 3.10, due to the use of `|` for type unions, which also seems reasonable, given that people that make runtime use of annotations tend to use newer version of Python and that 3.9 will be EOL in October. But if this is unacceptable, we can replace the few places we use the operator with `typing.Union` and `typing.Optional`.

This also fixes a couple of minor bugs that were discovered thanks to the static analysis provided by mypy.