### PR TITLE
Deleteding superfluous modulus operation

### DIFF
--- a/stdnum/jp/in_.py
+++ b/stdnum/jp/in_.py
@@ -61,7 +61,7 @@ def calc_check_digit(number: str) -> str:
     """Calculate the check digit. The number passed should not have
     the check digit included."""
     weights = (6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2)
-    s = sum(w * int(n) for w, n in zip(weights, number)) % 11
+    s = sum(w * int(n) for w, n in zip(weights, number))
     return str(-s % 11 % 10)
 
 


### PR DESCRIPTION
Since ``` -(x % 11) % 11 ``` and ``` -x % 11 ``` give always the same result, the first modulus operation can be safely deleted.

In the same way in the following code, the modulus in the fist line can be deleted with no effect on the output:
```  python
    s = sum(w * int(n) for w, n in zip(weights, number)) % 11
    return str(-s % 11 % 10)
``` 