### PR TITLE
Fix submodule visibility in country modules

### DIFF
--- a/stdnum/ar/__init__.py
+++ b/stdnum/ar/__init__.py
@@ -25,3 +25,4 @@ from __future__ import annotations
 # provide aliases
 from stdnum.ar import cuit as vat  # noqa: F401
 from stdnum.ar import dni as personalid  # noqa: F401
+from stdnum.ar import cbu  # noqa: F401

--- a/stdnum/at/__init__.py
+++ b/stdnum/at/__init__.py
@@ -26,3 +26,5 @@ from __future__ import annotations
 from stdnum.at import postleitzahl as postal_code  # noqa: F401
 from stdnum.at import uid as vat  # noqa: F401
 from stdnum.at import vnr as personalid  # noqa: F401
+from stdnum.at import businessid  # noqa: F401
+from stdnum.at import tin  # noqa: F401

--- a/stdnum/au/__init__.py
+++ b/stdnum/au/__init__.py
@@ -24,3 +24,5 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.au import abn as vat  # noqa: F401
+from stdnum.au import acn  # noqa: F401
+from stdnum.au import tfn  # noqa: F401

--- a/stdnum/be/__init__.py
+++ b/stdnum/be/__init__.py
@@ -25,3 +25,7 @@ from __future__ import annotations
 # provide businessid as an alias
 from stdnum.be import nn as personalid  # noqa: F401
 from stdnum.be import vat as businessid  # noqa: F401
+from stdnum.be import bis  # noqa: F401
+from stdnum.be import eid  # noqa: F401
+from stdnum.be import iban  # noqa: F401
+from stdnum.be import ssn  # noqa: F401

--- a/stdnum/bg/__init__.py
+++ b/stdnum/bg/__init__.py
@@ -19,3 +19,8 @@
 # 02110-1301 USA
 
 """Collection of Bulgarian numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.bg import egn  # noqa: F401
+from stdnum.bg import pnf  # noqa: F401
+from stdnum.bg import vat  # noqa: F401

--- a/stdnum/br/__init__.py
+++ b/stdnum/br/__init__.py
@@ -23,3 +23,4 @@
 from __future__ import annotations
 
 from stdnum.br import cnpj as vat  # noqa: F401
+from stdnum.br import cpf  # noqa: F401

--- a/stdnum/ca/__init__.py
+++ b/stdnum/ca/__init__.py
@@ -23,3 +23,5 @@
 from __future__ import annotations
 
 from stdnum.ca import bn as vat  # noqa: F401
+from stdnum.ca import bc_phn  # noqa: F401
+from stdnum.ca import sin  # noqa: F401

--- a/stdnum/ch/__init__.py
+++ b/stdnum/ch/__init__.py
@@ -19,3 +19,9 @@
 # 02110-1301 USA
 
 """Collection of Swiss numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.ch import esr  # noqa: F401
+from stdnum.ch import ssn  # noqa: F401
+from stdnum.ch import uid  # noqa: F401
+from stdnum.ch import vat  # noqa: F401

--- a/stdnum/cn/__init__.py
+++ b/stdnum/cn/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # Provide vat as an alias.
 from stdnum.cn import uscc as vat  # noqa: F401
+from stdnum.cn import ric  # noqa: F401

--- a/stdnum/cr/__init__.py
+++ b/stdnum/cr/__init__.py
@@ -23,3 +23,5 @@
 from __future__ import annotations
 
 from stdnum.cr import cpj as vat  # noqa: F401
+from stdnum.cr import cpf  # noqa: F401
+from stdnum.cr import cr  # noqa: F401

--- a/stdnum/cu/__init__.py
+++ b/stdnum/cu/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Cuban numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.cu import ni  # noqa: F401

--- a/stdnum/cy/__init__.py
+++ b/stdnum/cy/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Cypriot numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.cy import vat  # noqa: F401

--- a/stdnum/cz/__init__.py
+++ b/stdnum/cz/__init__.py
@@ -24,3 +24,5 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.cz import dic as vat  # noqa: F401
+from stdnum.cz import bankaccount  # noqa: F401
+from stdnum.cz import rc  # noqa: F401

--- a/stdnum/de/__init__.py
+++ b/stdnum/de/__init__.py
@@ -24,3 +24,7 @@ from __future__ import annotations
 
 # provide businessid as an alias
 from stdnum.de import handelsregisternummer as businessid  # noqa: F401
+from stdnum.de import idnr  # noqa: F401
+from stdnum.de import stnr  # noqa: F401
+from stdnum.de import vat  # noqa: F401
+from stdnum.de import wkn  # noqa: F401

--- a/stdnum/do/__init__.py
+++ b/stdnum/do/__init__.py
@@ -23,3 +23,5 @@
 from __future__ import annotations
 
 from stdnum.do import rnc as vat  # noqa: F401
+from stdnum.do import cedula  # noqa: F401
+from stdnum.do import ncf  # noqa: F401

--- a/stdnum/es/__init__.py
+++ b/stdnum/es/__init__.py
@@ -24,3 +24,12 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.es import nif as vat  # noqa: F401
+from stdnum.es import cae  # noqa: F401
+from stdnum.es import ccc  # noqa: F401
+from stdnum.es import cif  # noqa: F401
+from stdnum.es import cups  # noqa: F401
+from stdnum.es import dni  # noqa: F401
+from stdnum.es import iban  # noqa: F401
+from stdnum.es import nie  # noqa: F401
+from stdnum.es import postal_code  # noqa: F401
+from stdnum.es import referenciacatastral  # noqa: F401

--- a/stdnum/eu/__init__.py
+++ b/stdnum/eu/__init__.py
@@ -19,3 +19,12 @@
 # 02110-1301 USA
 
 """Collection of European Union numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.eu import at_02  # noqa: F401
+from stdnum.eu import banknote  # noqa: F401
+from stdnum.eu import ecnumber  # noqa: F401
+from stdnum.eu import eic  # noqa: F401
+from stdnum.eu import nace  # noqa: F401
+from stdnum.eu import oss  # noqa: F401
+from stdnum.eu import vat  # noqa: F401

--- a/stdnum/fi/__init__.py
+++ b/stdnum/fi/__init__.py
@@ -26,3 +26,5 @@ from __future__ import annotations
 from stdnum.fi import alv as vat  # noqa: F401
 from stdnum.fi import hetu as personalid  # noqa: F401
 from stdnum.fi import ytunnus as businessid  # noqa: F401
+from stdnum.fi import associationid  # noqa: F401
+from stdnum.fi import veronumero  # noqa: F401

--- a/stdnum/fr/__init__.py
+++ b/stdnum/fr/__init__.py
@@ -24,3 +24,7 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.fr import tva as vat  # noqa: F401
+from stdnum.fr import nif  # noqa: F401
+from stdnum.fr import nir  # noqa: F401
+from stdnum.fr import siren  # noqa: F401
+from stdnum.fr import siret  # noqa: F401

--- a/stdnum/gb/__init__.py
+++ b/stdnum/gb/__init__.py
@@ -19,3 +19,12 @@
 # 02110-1301 USA
 
 """Collection of United Kingdom numbers."""
+
+from __future__ import annotations
+
+# Import all submodules to make them available via dir()
+from stdnum.gb import nhs  # noqa: F401
+from stdnum.gb import sedol  # noqa: F401
+from stdnum.gb import upn  # noqa: F401
+from stdnum.gb import utr  # noqa: F401
+from stdnum.gb import vat  # noqa: F401

--- a/stdnum/gr/__init__.py
+++ b/stdnum/gr/__init__.py
@@ -19,3 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Greek numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.gr import amka  # noqa: F401
+from stdnum.gr import vat  # noqa: F401

--- a/stdnum/ie/__init__.py
+++ b/stdnum/ie/__init__.py
@@ -19,3 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Irish numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.ie import pps  # noqa: F401
+from stdnum.ie import vat  # noqa: F401

--- a/stdnum/il/__init__.py
+++ b/stdnum/il/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.il import hp as vat  # noqa: F401
+from stdnum.il import idnr  # noqa: F401

--- a/stdnum/in_/__init__.py
+++ b/stdnum/in_/__init__.py
@@ -24,3 +24,7 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.in_ import gstin as vat  # noqa: F401
+from stdnum.in_ import aadhaar  # noqa: F401
+from stdnum.in_ import epic  # noqa: F401
+from stdnum.in_ import pan  # noqa: F401
+from stdnum.in_ import vid  # noqa: F401

--- a/stdnum/it/__init__.py
+++ b/stdnum/it/__init__.py
@@ -24,3 +24,5 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.it import iva as vat  # noqa: F401
+from stdnum.it import aic  # noqa: F401
+from stdnum.it import codicefiscale  # noqa: F401

--- a/stdnum/jp/__init__.py
+++ b/stdnum/jp/__init__.py
@@ -23,3 +23,4 @@
 from __future__ import annotations
 
 from stdnum.jp import cn as vat  # noqa: F401
+from stdnum.jp import in_  # noqa: F401

--- a/stdnum/kr/__init__.py
+++ b/stdnum/kr/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.kr import brn as vat  # noqa: F401
+from stdnum.kr import rrn  # noqa: F401

--- a/stdnum/li/__init__.py
+++ b/stdnum/li/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Liechtenstein numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.li import peid  # noqa: F401

--- a/stdnum/lt/__init__.py
+++ b/stdnum/lt/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.lt import pvm as vat  # noqa: F401
+from stdnum.lt import asmens  # noqa: F401

--- a/stdnum/md/__init__.py
+++ b/stdnum/md/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Moldavian numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.md import idno  # noqa: F401

--- a/stdnum/me/__init__.py
+++ b/stdnum/me/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.me import pib as vat  # noqa: F401
+from stdnum.me import iban  # noqa: F401

--- a/stdnum/mt/__init__.py
+++ b/stdnum/mt/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Maltese numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.mt import vat  # noqa: F401

--- a/stdnum/mu/__init__.py
+++ b/stdnum/mu/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Mauritian numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.mu import nid  # noqa: F401

--- a/stdnum/my/__init__.py
+++ b/stdnum/my/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Malaysian numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.my import nric  # noqa: F401

--- a/stdnum/nl/__init__.py
+++ b/stdnum/nl/__init__.py
@@ -25,3 +25,7 @@ from __future__ import annotations
 # provide aliases
 from stdnum.nl import btw as vat  # noqa: F401
 from stdnum.nl import postcode as postal_code  # noqa: F401
+from stdnum.nl import brin  # noqa: F401
+from stdnum.nl import bsn  # noqa: F401
+from stdnum.nl import identiteitskaartnummer  # noqa: F401
+from stdnum.nl import onderwijsnummer  # noqa: F401

--- a/stdnum/no/__init__.py
+++ b/stdnum/no/__init__.py
@@ -25,3 +25,6 @@ from __future__ import annotations
 # provide aliases
 from stdnum.no import fodselsnummer as personalid  # noqa: F401
 from stdnum.no import mva as vat  # noqa: F401
+from stdnum.no import iban  # noqa: F401
+from stdnum.no import kontonr  # noqa: F401
+from stdnum.no import orgnr  # noqa: F401

--- a/stdnum/nz/__init__.py
+++ b/stdnum/nz/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.nz import ird as vat  # noqa: F401
+from stdnum.nz import bankaccount  # noqa: F401

--- a/stdnum/pe/__init__.py
+++ b/stdnum/pe/__init__.py
@@ -23,3 +23,4 @@
 from __future__ import annotations
 
 from stdnum.pe import ruc as vat  # noqa: F401
+from stdnum.pe import cui  # noqa: F401

--- a/stdnum/pk/__init__.py
+++ b/stdnum/pk/__init__.py
@@ -19,3 +19,6 @@
 # 02110-1301 USA
 
 """Collection of Pakistani numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.pk import cnic  # noqa: F401

--- a/stdnum/pl/__init__.py
+++ b/stdnum/pl/__init__.py
@@ -24,3 +24,5 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.pl import nip as vat  # noqa: F401
+from stdnum.pl import pesel  # noqa: F401
+from stdnum.pl import regon  # noqa: F401

--- a/stdnum/pt/__init__.py
+++ b/stdnum/pt/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.pt import nif as vat  # noqa: F401
+from stdnum.pt import cc  # noqa: F401

--- a/stdnum/ro/__init__.py
+++ b/stdnum/ro/__init__.py
@@ -24,3 +24,6 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ro import cf as vat  # noqa: F401
+from stdnum.ro import cnp  # noqa: F401
+from stdnum.ro import cui  # noqa: F401
+from stdnum.ro import onrc  # noqa: F401

--- a/stdnum/ru/__init__.py
+++ b/stdnum/ru/__init__.py
@@ -24,3 +24,4 @@ from __future__ import annotations
 
 # provide vat as an alias
 from stdnum.ru import inn as vat  # noqa: F401
+from stdnum.ru import ogrn  # noqa: F401

--- a/stdnum/se/__init__.py
+++ b/stdnum/se/__init__.py
@@ -25,3 +25,5 @@ from __future__ import annotations
 # provide aliases
 from stdnum.se import personnummer as personalid  # noqa: F401
 from stdnum.se import postnummer as postal_code  # noqa: F401
+from stdnum.se import orgnr  # noqa: F401
+from stdnum.se import vat  # noqa: F401

--- a/stdnum/th/__init__.py
+++ b/stdnum/th/__init__.py
@@ -24,3 +24,5 @@ from __future__ import annotations
 
 # provide aliases
 from stdnum.th import moa as vat  # noqa: F401
+from stdnum.th import pin  # noqa: F401
+from stdnum.th import tin  # noqa: F401

--- a/stdnum/tr/__init__.py
+++ b/stdnum/tr/__init__.py
@@ -23,3 +23,4 @@
 from __future__ import annotations
 
 from stdnum.tr import vkn as vat  # noqa: F401
+from stdnum.tr import tckimlik  # noqa: F401

--- a/stdnum/ua/__init__.py
+++ b/stdnum/ua/__init__.py
@@ -19,3 +19,7 @@
 # 02110-1301 USA
 
 """Collection of Ukrainian numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.ua import edrpou  # noqa: F401
+from stdnum.ua import rntrc  # noqa: F401

--- a/stdnum/us/__init__.py
+++ b/stdnum/us/__init__.py
@@ -19,3 +19,12 @@
 # 02110-1301 USA
 
 """Collection of United States numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.us import atin  # noqa: F401
+from stdnum.us import ein  # noqa: F401
+from stdnum.us import itin  # noqa: F401
+from stdnum.us import ptin  # noqa: F401
+from stdnum.us import rtn  # noqa: F401
+from stdnum.us import ssn  # noqa: F401
+from stdnum.us import tin  # noqa: F401

--- a/stdnum/za/__init__.py
+++ b/stdnum/za/__init__.py
@@ -19,3 +19,7 @@
 # 02110-1301 USA
 
 """Collection of South Africa numbers."""
+
+# Import all submodules to make them available via dir()
+from stdnum.za import idnr  # noqa: F401
+from stdnum.za import tin  # noqa: F401


### PR DESCRIPTION
Add explicit imports to __init__.py files for all country modules to make submodules visible via dir() function. This resolves the issue where submodules like stdnum.gb.nhs, stdnum.us.ssn, etc. were not discoverable through introspection despite being importable directly.

Changes:
- Added explicit 'from stdnum.{country} import {module}' statements
- Added '# noqa: F401' comments to suppress unused import warnings
- Ensures all submodules are now visible in dir() output
- Maintains backward compatibility for direct imports

Fixes module discoverability for all country-specific validation modules.