### PR TITLE
Fix type annotations and bump mypy python_version for mypy 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,6 @@ known_third_party =
   xlrd
 
 [mypy]
-python_version = 3.9
+python_version = 3.10
 strict = True
 warn_unreachable = True

--- a/stdnum/eu/vat.py
+++ b/stdnum/eu/vat.py
@@ -56,7 +56,7 @@ MEMBER_STATES = set([
 country code of gr while for VAT purposes el is used instead. For Northern
 Ireland numbers are prefixed with xi of United Kingdom numbers."""
 
-_country_modules = dict()
+_country_modules: dict[str, NumberValidationModule | None] = {}
 
 vies_wsdl = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl'
 """The WSDL URL of the VAT Information Exchange System (VIES)."""

--- a/stdnum/util.py
+++ b/stdnum/util.py
@@ -256,7 +256,7 @@ def get_cc_module(cc: str, name: str) -> NumberValidationModule | None:
 
 
 # this is a cache of SOAP clients
-_soap_clients = {}
+_soap_clients: dict[tuple[str, float, bool | str], Any] = {}
 
 
 def _get_zeep_soap_client(


### PR DESCRIPTION
mypy 2.0 dropped support for `python_version = 3.9` in the `[mypy]` config and flagged two empty-dict definitions as missing annotations, which currently breaks the `tox -e mypy` CI job on any new commit.

- Bump `python_version` in `setup.cfg` from 3.9 to 3.10.
- Annotate `_soap_clients` in `stdnum/util.py`.
- Annotate `_country_modules` in `stdnum/eu/vat.py`, which also resolves the `no-any-return` warning in `_get_cc_module`.