### PR TITLE
ro/cf: strip RO country prefix in compact() for consistent output

### DIFF
--- a/stdnum/ro/cf.py
+++ b/stdnum/ro/cf.py
@@ -20,8 +20,8 @@
 
 The Romanian CF is used for VAT purposes and can be from 2 to 10 digits long.
 
->>> validate('RO 185 472 90')  # VAT CUI/CIF
-'RO18547290'
+>>> validate('RO 185 472 90')  # VAT CUI/CIF (RO prefix is stripped)
+'18547290'
 >>> validate('185 472 90')  # non-VAT CUI/CIF
 '18547290'
 >>> validate('1630615123457')  # CNP
@@ -37,8 +37,12 @@ from stdnum.util import clean
 
 def compact(number: str) -> str:
     """Convert the number to the minimal representation. This strips the
-    number of any valid separators and removes surrounding whitespace."""
-    return clean(number, ' -').upper().strip()
+    number of any valid separators and removes surrounding whitespace. The
+    optional RO country prefix is removed to return the domestic form."""
+    number = clean(number, ' -').upper().strip()
+    if number.startswith('RO'):
+        number = number[2:]
+    return number
 
 
 # for backwards compatibility
@@ -49,13 +53,10 @@ def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
-    cnumber = number
-    if cnumber.startswith('RO'):
-        cnumber = cnumber[2:]
-    if len(cnumber) == 13:
+    if len(number) == 13:
         # apparently a CNP can also be used (however, not all sources agree)
-        cnp.validate(cnumber)
-    elif 2 <= len(cnumber) <= 10:
+        cnp.validate(number)
+    elif 2 <= len(number) <= 10:
         cui.validate(number)
     else:
         raise InvalidLength()

--- a/stdnum/ro/cf.py
+++ b/stdnum/ro/cf.py
@@ -22,6 +22,10 @@ The Romanian CF is used for VAT purposes and can be from 2 to 10 digits long.
 
 >>> validate('RO 185 472 90')  # VAT CUI/CIF (RO prefix is stripped)
 '18547290'
+>>> validate('RO RO 16621241')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
 >>> validate('185 472 90')  # non-VAT CUI/CIF
 '18547290'
 >>> validate('1630615123457')  # CNP
@@ -32,7 +36,7 @@ from __future__ import annotations
 
 from stdnum.exceptions import *
 from stdnum.ro import cnp, cui
-from stdnum.util import clean
+from stdnum.util import clean, isdigits
 
 
 def compact(number: str) -> str:
@@ -53,6 +57,8 @@ def validate(number: str) -> str:
     """Check if the number is a valid VAT number. This checks the length,
     formatting and check digit."""
     number = compact(number)
+    if not isdigits(number):
+        raise InvalidFormat()
     if len(number) == 13:
         # apparently a CNP can also be used (however, not all sources agree)
         cnp.validate(number)


### PR DESCRIPTION
## Description

Fixes #485. `stdnum.ro.cf` produced inconsistent output depending on whether the optional `RO` country prefix was present in the input:

```python
>>> validate('RO 185 472 90')
'RO18547290'          # before
>>> validate('185 472 90')
'18547290'
```

Both inputs denote the same number, but `compact()` did not strip the `RO` prefix the way the `cui.compact()` it delegates to (and other country modules such as `pl/nip`) do.

## Fix

- `compact()` now strips the `RO` prefix, returning the domestic form — matching `cui.compact()` and sibling modules.
- `validate()` is simplified: the manual `RO` split is removed since `compact()` now handles it.
- The docstring example is updated to reflect `'18547290'`.

`validate('RO 185 472 90')` and `validate('185 472 90')` now both return `'18547290'`.

This pull request was prepared with the assistance of AI, under my direction and review.
