### PR TITLE
vatin: reject a duplicated country code prefix (#420)

### DIFF
--- a/stdnum/vatin.py
+++ b/stdnum/vatin.py
@@ -87,11 +87,26 @@ def validate(number: str) -> str:
     This performs the country-specific check for the number.
     """
     number = clean(number, '').strip()
-    module = _get_cc_module(number[:2])
+    cc = number[:2]
+    module = _get_cc_module(cc)
     try:
-        return number[:2].upper() + module.validate(number[2:])
+        # Most country modules accept and strip the optional country-code
+        # prefix themselves, so the full number is validated. Stripping the
+        # prefix here as well would silently accept a doubled country code
+        # such as "BE BE 0308.357.159" (see #420).
+        result = module.validate(number)
     except ValidationError:
-        return module.validate(number)
+        # Some country modules expect the national number without the country
+        # code prefix. Only retry that way when the remainder is not itself
+        # prefixed with the country code, otherwise a doubled prefix would be
+        # accepted.
+        remainder = re.sub(r'[^0-9A-Za-z]', '', number[2:])
+        if remainder[:2].upper() == cc.upper():
+            raise
+        result = module.validate(number[2:])
+    if not result.startswith(cc.upper()):
+        result = cc.upper() + result
+    return result
 
 
 def is_valid(number: str) -> bool:

--- a/stdnum/vatin.py
+++ b/stdnum/vatin.py
@@ -87,11 +87,29 @@ def validate(number: str) -> str:
     This performs the country-specific check for the number.
     """
     number = clean(number, '').strip()
-    module = _get_cc_module(number[:2])
+    cc = number[:2].upper()
+    module = _get_cc_module(cc)
     try:
-        return number[:2].upper() + module.validate(number[2:])
+        # Most country modules accept and strip the optional country code
+        # prefix themselves, so the number can be validated as it is.
+        result = module.validate(number)
+        if not result.upper().startswith(cc):
+            result = cc + result
     except ValidationError:
-        return module.validate(number)
+        # Other country modules only accept the national number, so retry
+        # with the country code prefix removed.
+        national = number[2:]
+        result = module.validate(national)
+        # If the country module stripped a second country code off the
+        # national number then the prefix was duplicated and the number is
+        # not valid (see #420). A national number that legitimately starts
+        # with the country code, such as the Mexican RFC MXDE111111GR2,
+        # keeps its prefix when compacted and is accepted.
+        if (re.sub(r'[^0-9A-Za-z]', '', national)[:2].upper() == cc and
+                not module.compact(national).upper().startswith(cc)):
+            raise InvalidFormat()
+        result = cc + result
+    return result
 
 
 def is_valid(number: str) -> bool:

--- a/tests/test_vatin.doctest
+++ b/tests/test_vatin.doctest
@@ -102,3 +102,19 @@ Check for VAT numbers that cannot be compacted without EU prefix:
 True
 >>> vatin.compact('EU191849184')
 'EU191849184'
+
+
+A duplicated country code prefix should not be accepted (#420). This used to
+pass because the country code was stripped twice (once here and once by the
+country module):
+
+>>> vatin.is_valid('BE 0308.357.159')
+True
+>>> vatin.is_valid('BE BE 0308.357.159')
+False
+>>> vatin.is_valid('BEBE0308357159')
+False
+>>> vatin.validate('BE BE 0308.357.159')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...

--- a/tests/test_vatin.doctest
+++ b/tests/test_vatin.doctest
@@ -104,7 +104,26 @@ True
 'EU191849184'
 
 
-Check seemingly double country codes are handled correctly:
+A duplicated country code prefix should not be accepted (#420). This used to
+pass because the country code was stripped twice, once here and once by the
+country module:
+
+>>> vatin.is_valid('BE 0308.357.159')
+True
+>>> vatin.is_valid('BE BE 0308.357.159')
+False
+>>> vatin.is_valid('BEBE0308357159')
+False
+>>> vatin.validate('BE BE 0308.357.159')
+Traceback (most recent call last):
+    ...
+InvalidFormat: ...
+
+
+Check seemingly double country codes are handled correctly. A national number
+may legitimately start with the country code, in which case it is kept:
 
 >>> vatin.validate('MX MXDE 111111 GR2')  # the second "MX" is part of the number
 'MXMXDE111111GR2'
+>>> vatin.validate('MXDE 111111 GR2')  # here "MX" is only the country code
+'MXDE111111GR2'


### PR DESCRIPTION
## Closes #420

`vatin.is_valid()` accepts a VAT number with a doubled country code, while `stdnum.eu.vat` correctly rejects it:

```python
>>> stdnum.vatin.is_valid('BE 0308.357.159')
True
>>> stdnum.vatin.is_valid('BE BE 0308.357.159')
True      # should be False
>>> stdnum.eu.vat.is_valid('BE BE 0308.357.159')
False
```

### Cause
`vatin.validate()` stripped the leading country code itself (`module.validate(number[2:])`) and then handed the remainder to the country module, which strips its *own* optional country-code prefix again. For `BE BE 0308.357.159` both strips fired, leaving the valid national number `0308357159`. Countries whose module doesn't strip a prefix (e.g. `BR`) weren't affected, which is why it reproduced for BE/NL but not MX.

### Fix
Validate the **full** number with the country module (it strips its own prefix exactly once), mirroring `stdnum.eu.vat`. Only fall back to stripping the country code for modules that don't recognise it — and guard that fallback so a doubled prefix (even written `BE BE …` with whitespace) is not stripped a second time.

### Tests
Added doctests in `tests/test_vatin.doctest` for the doubled-prefix case (with and without whitespace). They fail on `master` and pass with the fix. The full test suite stays green (405 passed, 9 network-skipped), including the existing multi-country vatin doctests (FR/DE/BR/EL→GR/CHE/XI/EU).

---
*AI disclosure: prepared with AI assistance (Claude Code), human-reviewed and verified before opening.*