### PR TITLE
Update Taiwan UBN check digit for the 2023 rule change (divisible by 5)

### DIFF
--- a/stdnum/tw/ubn.py
+++ b/stdnum/tw/ubn.py
@@ -22,9 +22,15 @@ The Unified Business Number (UBN, 統一編號) is the number assigned to busine
 within Taiwan for tax (VAT) purposes. The number consists of 8 digits, the
 last being a check digit.
 
+Since 2023-04-01 (民國112年) the Ministry of Finance relaxed the check digit
+logic so that the weighted sum only needs to be divisible by 5 (instead of 10)
+to increase the pool of available numbers. Numbers that were valid under the
+old rule (divisible by 10) remain valid under the new one.
+
 More information:
 
 * https://zh.wikipedia.org/wiki/統一編號
+* https://www.fia.gov.tw/singlehtml/3?cntId=c4d9cff38c8642ef8872774ee9987283
 * https://findbiz.nat.gov.tw/fts/query/QueryBar/queryInit.do?request_locale=en
 
 >>> validate('00501503')
@@ -61,7 +67,7 @@ def calc_checksum(number: str) -> int:
     # convert to numeric first, then sum individual digits
     weights = (1, 2, 1, 2, 1, 2, 4, 1)
     number = ''.join(str(w * int(n)) for w, n in zip(weights, number))
-    return sum(int(n) for n in number) % 10
+    return sum(int(n) for n in number) % 5
 
 
 def validate(number: str) -> str:
@@ -75,7 +81,8 @@ def validate(number: str) -> str:
     if not isdigits(number):
         raise InvalidFormat()
     checksum = calc_checksum(number)
-    if not (checksum == 0 or (checksum == 9 and number[6] == '7')):
+    # if the 7th digit is 7 the check may also pass when adding 1 to the sum
+    if not (checksum == 0 or (checksum == 4 and number[6] == '7')):
         raise InvalidChecksum()
     return number
 

--- a/stdnum/tw/ubn.py
+++ b/stdnum/tw/ubn.py
@@ -22,10 +22,10 @@ The Unified Business Number (UBN, 統一編號) is the number assigned to busine
 within Taiwan for tax (VAT) purposes. The number consists of 8 digits, the
 last being a check digit.
 
-Since 2023-04-01 (民國112年) the Ministry of Finance relaxed the check digit
-logic so that the weighted sum only needs to be divisible by 5 (instead of 10)
-to increase the pool of available numbers. Numbers that were valid under the
-old rule (divisible by 10) remain valid under the new one.
+Since 2023-04-01 the Ministry of Finance relaxed the check digit logic so
+that the weighted sum only needs to be divisible by 5 (instead of 10) to
+increase the pool of available numbers. Numbers that were valid under the old
+rule (divisible by 10) remain valid under the new one.
 
 More information:
 

--- a/tests/test_tw_ubn.doctest
+++ b/tests/test_tw_ubn.doctest
@@ -45,6 +45,21 @@ Traceback (most recent call last):
 InvalidChecksum: ...
 
 
+Since 2023-04-01 the check digit only needs the weighted sum to be divisible
+by 5 (instead of 10), so numbers that were invalid under the old rule may now
+be valid. The special case for a 7 in the 7th position (where 1 may be added
+to the sum) still applies.
+
+>>> ubn.validate('10000004')
+'10000004'
+>>> ubn.validate('10000026')
+'10000026'
+>>> ubn.validate('10000073')
+'10000073'
+>>> ubn.validate('10000171')
+'10000171'
+
+
 These have been found online and should all be valid numbers.
 
 >>> numbers = '''

--- a/tests/test_tw_ubn.doctest
+++ b/tests/test_tw_ubn.doctest
@@ -45,10 +45,20 @@ Traceback (most recent call last):
 InvalidChecksum: ...
 
 
+Under the old rule the weighted sum had to be divisible by 10. These numbers
+(including the special case for a 7 in the 7th position, where 1 may be added
+to the sum) remain valid.
+
+>>> ubn.validate('01000008')
+'01000008'
+>>> ubn.validate('01000077')
+'01000077'
+>>> ubn.validate('01000175')
+'01000175'
+
 Since 2023-04-01 the check digit only needs the weighted sum to be divisible
 by 5 (instead of 10), so numbers that were invalid under the old rule may now
-be valid. The special case for a 7 in the 7th position (where 1 may be added
-to the sum) still applies.
+be valid. The special case for a 7 in the 7th position still applies.
 
 >>> ubn.validate('10000004')
 '10000004'


### PR DESCRIPTION
## Summary

Taiwan's Ministry of Finance relaxed the check digit logic for the UBN
(Unified Business Number, 統一編號) effective **2023-04-01**. The weighted sum
now only needs to be **divisible by 5** instead of 10, enlarging the pool of
assignable numbers as the old space is being exhausted.

- Numbers valid under the old rule (divisible by 10) remain valid under the
  new one, since divisibility by 10 implies divisibility by 5. No previously
  valid number is rejected — consistent with the guideline that marking valid
  numbers as invalid must be avoided.
- The special case for a `7` in the 7th position (where 1 may be added to the
  sum before the divisibility check) is preserved, now evaluated against
  divisibility by 5.

## Changes

- `stdnum/tw/ubn.py`: `calc_checksum` now returns the weighted sum mod 5;
  `validate` accepts `checksum == 0`, or `checksum == 4` when the 7th digit is
  `7`. The module docstring documents the rule change with an official reference.
- `tests/test_tw_ubn.doctest`: added old-rule numbers (divisible by 10,
  including the 7th-digit-is-`7` case) to confirm they stay valid, plus new-rule
  numbers (divisible by 5 but not 10, including the 7th-digit-is-`7` case).

## Reference

Fiscal Information Agency, Ministry of Finance — explanation of the revised
UBN check digit logic:
https://www.fia.gov.tw/singlehtml/3?cntId=c4d9cff38c8642ef8872774ee9987283