### PR TITLE
Strip comma instead of keyboard-adjacent m when compacting CID

### DIFF
--- a/stdnum/eu/at_02.py
+++ b/stdnum/eu/at_02.py
@@ -33,7 +33,7 @@ contains the country-specific identifier.
 >>> compact('ES++()+23ZZZ4//7690558N')
 'ES23ZZZ47690558N'
 >>> compact('mt50zzz670169305t') # EPC262-08 Version 12.0 / 8.1.15 Malta, example identifier, lowercased
-'T50ZZZ670169305T'
+'MT50ZZZ670169305T'
 >>> calc_check_digits('ESXXZZZ47690558N')
 '23'
 """
@@ -52,7 +52,7 @@ _alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 def compact(number: str) -> str:
     """Convert the AT-02 number to the minimal representation. This strips
     the number of any valid separators and removes invalid characters."""
-    return clean(number, ' -/?:().m\'+"').strip().upper()
+    return clean(number, ' -/?:().,\'+"').strip().upper()
 
 
 def _to_base10(number: str) -> str:

--- a/stdnum/eu/at_02.py
+++ b/stdnum/eu/at_02.py
@@ -32,6 +32,8 @@ contains the country-specific identifier.
 'ES2300047690558N'
 >>> compact('ES++()+23ZZZ4//7690558N')
 'ES23ZZZ47690558N'
+>>> compact('mt50zzz670169305t') # EPC262-08 Version 12.0 / 8.1.15 Malta, example identifier, lowercased
+'T50ZZZ670169305T'
 >>> calc_check_digits('ESXXZZZ47690558N')
 '23'
 """


### PR DESCRIPTION
It does look like once upon a 2014 the author of stdnum.eu.at_02 hit `m` when intending to hit `,` while typing the list of characters to strip from CIDs, as the [documentation](https://www.europeanpaymentscouncil.eu/sites/default/files/kb/file/2025-10/EPC262-08%20v12.0%20Creditor%20Identifier%20Overview.pdf) for it offers no more plausible theories that I can tell, no special meaning is given to an `m` or `M` or their complement there :D

E.g. the Maltese example MT50ZZZ670169305T from the documentation, if provided in lowercase, would lose its M in compacting, as demonstrated by the test in the first commit. Strip the keyboard-adjacent punctuation instead.